### PR TITLE
Drop SwaggerResponse in Return Type

### DIFF
--- a/src/HttpHandlers/OauthClientCredentialsHandler.cs
+++ b/src/HttpHandlers/OauthClientCredentialsHandler.cs
@@ -52,7 +52,7 @@ namespace Laserfiche.Api.Client.HttpHandlers
             if (string.IsNullOrEmpty(_accessToken))
             {
                 var response = await _tokenApiClient.GetAccessTokenAsync(_servicePrincipalKey, _accessKey, cancellationToken);
-                _accessToken = response.Result.Access_token;
+                _accessToken = response.Access_token;
             }
 
             httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);

--- a/src/OAuth/ITokenApiClient.cs
+++ b/src/OAuth/ITokenApiClient.cs
@@ -15,6 +15,6 @@ namespace Laserfiche.Api.Client.OAuth
         /// <param name="accessKey"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<SwaggerResponse<GetAccessTokenResponse>> GetAccessTokenAsync(string servicePrincipalKey, AccessKey accessKey, CancellationToken cancellationToken = default);
+        Task<GetAccessTokenResponse> GetAccessTokenAsync(string servicePrincipalKey, AccessKey accessKey, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OAuth/OAuthClient.cs
+++ b/src/OAuth/OAuthClient.cs
@@ -29,7 +29,7 @@ namespace Laserfiche.Api.Client.OAuth
         /// <br/>- Use Bearer header to generate access token for the client credential flow. This uses grant_type and bearer auth header.
         /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<SwaggerResponse<GetAccessTokenResponse>> TokenAsync(GetAccessTokenRequest body = null, string authorization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<GetAccessTokenResponse> TokenAsync(GetAccessTokenRequest body = null, string authorization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
     }
 
@@ -68,7 +68,7 @@ namespace Laserfiche.Api.Client.OAuth
         /// <br/>- Use Bearer header to generate access token for the client credential flow. This uses grant_type and bearer auth header.
         /// </summary>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<SwaggerResponse<GetAccessTokenResponse>> TokenAsync(GetAccessTokenRequest body = null, string authorization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<GetAccessTokenResponse> TokenAsync(GetAccessTokenRequest body = null, string authorization = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append("Token");
@@ -118,7 +118,7 @@ namespace Laserfiche.Api.Client.OAuth
                             {
                                 throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                             }
-                            return new SwaggerResponse<GetAccessTokenResponse>(status_, headers_, objectResponse_.Object);
+                            return objectResponse_.Object;
                         }
                         else
                         if (status_ == 400)
@@ -367,32 +367,6 @@ namespace Laserfiche.Api.Client.OAuth
 
     }
 
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class SwaggerResponse
-    {
-        public int StatusCode { get; private set; }
-
-        public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
-
-        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
-        {
-            StatusCode = statusCode;
-            Headers = headers;
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class SwaggerResponse<TResult> : SwaggerResponse
-    {
-        public TResult Result { get; private set; }
-
-        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result)
-            : base(statusCode, headers)
-        {
-            Result = result;
-        }
-    }
 
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]

--- a/src/OAuth/TokenApiClient.cs
+++ b/src/OAuth/TokenApiClient.cs
@@ -36,7 +36,7 @@ namespace Laserfiche.Api.Client.OAuth
         /// <param name="accessKey"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<SwaggerResponse<GetAccessTokenResponse>> GetAccessTokenAsync(string servicePrincipalKey, AccessKey accessKey, CancellationToken cancellationToken = default)
+        public async Task<GetAccessTokenResponse> GetAccessTokenAsync(string servicePrincipalKey, AccessKey accessKey, CancellationToken cancellationToken = default)
         {
             if (!string.Equals(_httpClient.BaseAddress.AbsoluteUri, DomainUtils.GetOAuthApiBaseUri(accessKey.Domain), StringComparison.InvariantCultureIgnoreCase))
             {

--- a/tests/integration/TokenApiClientTests.cs
+++ b/tests/integration/TokenApiClientTests.cs
@@ -18,7 +18,7 @@ namespace Laserfiche.Api.Client.IntegrationTest
             var response = await client.GetAccessTokenAsync(ServicePrincipalKey, AccessKey);
             Assert.IsNotNull(response);
 
-            var tokenResponse = response.Result;
+            var tokenResponse = response;
 
             Assert.IsNotNull(tokenResponse.Access_token);
             Assert.IsNotNull(tokenResponse.Expires_in);

--- a/tests/unit/TokenApiClientTests.cs
+++ b/tests/unit/TokenApiClientTests.cs
@@ -32,7 +32,7 @@ namespace Laserfiche.Api.Client.UnitTest
         public void Setup()
         {
             mockTokenApiClient = new Mock<TokenApiClient>(DOMAIN);
-            mockTokenApiClient.Setup(tokenApiClient => tokenApiClient.TokenAsync(It.IsAny<GetAccessTokenRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new SwaggerResponse<GetAccessTokenResponse>(200, null, null)));
+            mockTokenApiClient.Setup(tokenApiClient => tokenApiClient.TokenAsync(It.IsAny<GetAccessTokenRequest>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new GetAccessTokenResponse()));
 
             servicePrincipalKey = SERVICE_PRINCIPAL_KEY;
             accessKey = new AccessKey()


### PR DESCRIPTION
The API responses for the oauth C# client lib returns a wrapper that contains info like the headers, statuscode, etc. We decided this is not needed since we also throw an exception when there are non-happy path status codes. The wrapper is only useful for letting users parse the status code to decide what to do. If the wrapper is only returned in the successful response, then it is not needed.