### PR TITLE
Disable the option to allow `dotnet pack` command to product a nuget …

### DIFF
--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -23,7 +23,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RepositoryUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <FileVersion>1.0.1.0</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
The `dotnet pack` command failed to produce a nuget package. A quick investigation shows [this](https://steveellwoodnlc.medium.com/error-nu5026-the-file-to-be-packed-was-not-found-on-disk-18bfbc6be4a) is the cause and the fix mentioned in the blog works.

Fix #22 