### PR TITLE
Fix log message for integration test when env is not found

### DIFF
--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -21,9 +21,9 @@ namespace Laserfiche.Api.Client.IntegrationTest
 
         private static void TryLoadFromDotEnv(string fileName)
         {
-            try
+            var path = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, fileName);
+            if (File.Exists(path))
             {
-                var path = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, fileName);
                 DotNetEnv.Env.Load(path, new DotNetEnv.LoadOptions(
                     setEnvVars: true,
                     clobberExistingVars: true,
@@ -31,7 +31,7 @@ namespace Laserfiche.Api.Client.IntegrationTest
                 ));
                 System.Diagnostics.Trace.TraceWarning($"{fileName} found. {fileName} file should only be used in local developer computers.");
             }
-            catch
+            else
             {
                 System.Diagnostics.Trace.WriteLine($"{fileName} not found.");
             }

--- a/tests/integration/OAuthClientCredentialsHandlerTests.cs
+++ b/tests/integration/OAuthClientCredentialsHandlerTests.cs
@@ -9,12 +9,6 @@ namespace Laserfiche.Api.Client.IntegrationTest
     public class OAuthClientCredentialsHandlerTests : BaseTest
     {
         [TestMethod]
-        public async Task BeforeSendAsync_Fail()
-        {
-            Assert.Fail("Test failed");
-        }
-
-        [TestMethod]
         public async Task BeforeSendAsync_Success()
         {
             var httpRequestHandler = new OAuthClientCredentialsHandler(ServicePrincipalKey, AccessKey);

--- a/tests/integration/OAuthClientCredentialsHandlerTests.cs
+++ b/tests/integration/OAuthClientCredentialsHandlerTests.cs
@@ -9,6 +9,12 @@ namespace Laserfiche.Api.Client.IntegrationTest
     public class OAuthClientCredentialsHandlerTests : BaseTest
     {
         [TestMethod]
+        public async Task BeforeSendAsync_Fail()
+        {
+            Assert.Fail("Test failed");
+        }
+
+        [TestMethod]
         public async Task BeforeSendAsync_Success()
         {
             var httpRequestHandler = new OAuthClientCredentialsHandler(ServicePrincipalKey, AccessKey);


### PR DESCRIPTION
The correct log message appears now when env file not exists
![image](https://user-images.githubusercontent.com/102689343/171211020-f7a444f3-40d8-4061-a74f-d97f762416b0.png)
