### PR TITLE
update version to 1.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,12 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.1.0"
+  VERSION_PREFIX: "1.2.0"
 
 jobs:
   build-n-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
 
@@ -41,6 +42,7 @@ jobs:
 
   build-documentation:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
 
   publish-documentation:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: documentation
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
@@ -119,6 +120,7 @@ jobs:
 
   publish-preview-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
@@ -155,6 +157,7 @@ jobs:
 
   publish-production-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -5,9 +5,9 @@
     <PackageId>Laserfiche.Api.Client.Core</PackageId>
     <Authors>Laserfiche</Authors>
     <Company>Laserfiche</Company>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <FileVersion>1.2.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</PackageProjectUrl>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
     <PackageTags>Laserfiche OAuth OAuth2 Authentication Authorization</PackageTags>


### PR DESCRIPTION
- update version to 1.2.0
- add timeouts to steps in the workflow. These steps normally take less than a minute, so having the 10 min timeout should be more than enough. The default timeout is 2 hours https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes