### PR TITLE
On prem integration test

### DIFF
--- a/tests/integration/LfdsUsernamePasswordHandlerTests.cs
+++ b/tests/integration/LfdsUsernamePasswordHandlerTests.cs
@@ -13,11 +13,11 @@ using System.Net;
 namespace Laserfiche.Api.Client.IntegrationTest
 {
     [TestClass]
-    [TestCategory("LFDS")]
     public class LfdsUsernamePasswordHandlerTest : BaseTest
     {
         private IHttpRequestHandler _httpRequestHandler;
 
+        [TestCategory("LFDS")]
         [TestMethod]
         public async Task BeforeSendAsync_NewToken_Success()
         {

--- a/tests/integration/LfdsUsernamePasswordHandlerTests.cs
+++ b/tests/integration/LfdsUsernamePasswordHandlerTests.cs
@@ -59,7 +59,7 @@ namespace Laserfiche.Api.Client.IntegrationTest
         public async Task BeforeSendAsync_FailedAuthentication_ThrowsException(string username, string password, string organization)
         {
             //Arrange
-            _httpRequestHandler = new LfdsUsernamePasswordHandler(username, password, RepoId, organization, BaseUrl);
+            _httpRequestHandler = new LfdsUsernamePasswordHandler(username, password, organization, RepoId, BaseUrl);
             using var request = new HttpRequestMessage();
 
             // Assert
@@ -79,10 +79,6 @@ namespace Laserfiche.Api.Client.IntegrationTest
             yield return new object[]
             {
                 baseTest.Username, "invalid password", baseTest.Organization
-            };
-            yield return new object[]
-            {
-                baseTest.Username, baseTest.Password, "invalid organization"
             };
         }
 


### PR DESCRIPTION
Modified integration test for LFDS handler:
- Fix the error of invalid repo Id caused by the wrong parameter order of the constructor
- Fix the negative test case so that an invalid organization will have no effect in the authentication
- Fix the issue of reaching the session limit on the on-prem server by cleaning up the sessions created in each test run.