### PR TITLE
Issue/52 remove dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.2.2"
+  VERSION_PREFIX: "1.2.3"
 
 jobs:
   build-n-test:

--- a/apiserver-nswag.json
+++ b/apiserver-nswag.json
@@ -15,9 +15,9 @@
       "output": "src/APIServer/TokenClient.cs",
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
       "generateClientInterfaces": true,
+      "generateDataAnnotations": false,
       "generateOptionalParameters": true,
-      "useBaseUrl": false,
-      "generateDataAnnotations": false
+      "useBaseUrl": false
     }
   }
 }

--- a/apiserver-nswag.json
+++ b/apiserver-nswag.json
@@ -16,7 +16,8 @@
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
       "generateClientInterfaces": true,
       "generateOptionalParameters": true,
-      "useBaseUrl": false
+      "useBaseUrl": false,
+      "generateDataAnnotations": false
     }
   }
 }

--- a/oauth-nswag.json
+++ b/oauth-nswag.json
@@ -15,9 +15,9 @@
       "output": "src/OAuth/OAuthClient.cs",
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
       "generateClientInterfaces": true,
+      "generateDataAnnotations": false,
       "generateOptionalParameters": true,
-      "useBaseUrl": false,
-      "generateDataAnnotations": false
+      "useBaseUrl": false
     }
   }
 }

--- a/oauth-nswag.json
+++ b/oauth-nswag.json
@@ -16,7 +16,8 @@
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
       "generateClientInterfaces": true,
       "generateOptionalParameters": true,
-      "useBaseUrl": false
+      "useBaseUrl": false,
+      "generateDataAnnotations": false
     }
   }
 }

--- a/src/APIServer/TokenClient.cs
+++ b/src/APIServer/TokenClient.cs
@@ -361,7 +361,6 @@ namespace Laserfiche.Api.Client.APIServer
         /// The value MUST be "password".
         /// </summary>
         [Newtonsoft.Json.JsonProperty("grant_type", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
         public string Grant_type { get; set; }
 
         /// <summary>

--- a/src/APIServer/TokenClientPartial.cs
+++ b/src/APIServer/TokenClientPartial.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace Laserfiche.Api.Client.APIServer
+{
+    partial class TokenClient
+    {
+        partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+        {
+            settings.MaxDepth = 128;
+        }
+    }
+}

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -31,7 +31,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -5,9 +5,9 @@
     <PackageId>Laserfiche.Api.Client.Core</PackageId>
     <Authors>Laserfiche</Authors>
     <Company>Laserfiche</Company>
-    <Version>1.2.2</Version>
-    <AssemblyVersion>1.2.2.0</AssemblyVersion>
-    <FileVersion>1.2.2.0</FileVersion>
+    <Version>1.2.3</Version>
+    <AssemblyVersion>1.2.3.0</AssemblyVersion>
+    <FileVersion>1.2.3.0</FileVersion>
     <PackageProjectUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>Laserfiche OAuth OAuth2 Authentication Authorization</PackageTags>

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -9,7 +9,7 @@
     <AssemblyVersion>1.2.2.0</AssemblyVersion>
     <FileVersion>1.2.2.0</FileVersion>
     <PackageProjectUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</PackageProjectUrl>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>Laserfiche OAuth OAuth2 Authentication Authorization</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OAuth/OAuthClient.cs
+++ b/src/OAuth/OAuthClient.cs
@@ -332,7 +332,6 @@ namespace Laserfiche.Api.Client.OAuth
         /// The value MUST be either of "authorization_code", "refresh_token", or "client_credentials".
         /// </summary>
         [Newtonsoft.Json.JsonProperty("grant_type", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
         public string Grant_type { get; set; }
 
         /// <summary>

--- a/src/OAuth/TokenClient.cs
+++ b/src/OAuth/TokenClient.cs
@@ -77,5 +77,10 @@ namespace Laserfiche.Api.Client.OAuth
             }, basicAuth);
             return response;
         }
+
+        partial void UpdateJsonSerializerSettings(JsonSerializerSettings settings)
+        {
+            settings.MaxDepth = 128;
+        }
     }
 }

--- a/src/Utils/DomainUtils.cs
+++ b/src/Utils/DomainUtils.cs
@@ -5,31 +5,6 @@ namespace Laserfiche.Api.Client.Utils
     public static class DomainUtils
     {
         /// <summary>
-        /// Returns the Laserfiche domain using the Laserfiche account id.
-        /// </summary>
-        /// <param name="accountId">The Laserfiche account id.</param>
-        /// <returns>The Laserfiche domain.</returns>
-        public static string GetDomainFromAccountId(string accountId)
-        {
-            if (accountId?.Length == 10)
-            {
-                if (accountId.StartsWith("1"))
-                {
-                    return "laserfiche.ca";
-                }
-                else if (accountId.StartsWith("2"))
-                {
-                    return "eu.laserfiche.com";
-                }
-            }
-            else if (accountId?.Length == 9)
-            {
-                return "laserfiche.com";
-            }
-            throw new ArgumentOutOfRangeException(nameof(accountId));
-        }
-
-        /// <summary>
         /// Returns the OAuth Api base uri using the given domain.
         /// </summary>
         /// <param name="domain">The Laserfiche domain.</param>

--- a/tests/unit/DomainUtilsTests.cs
+++ b/tests/unit/DomainUtilsTests.cs
@@ -8,41 +8,6 @@ namespace Laserfiche.Api.Client.UnitTest
     public class DomainUtilTest
     {
         [TestMethod]
-        public void GetDomainFromAccountId_US()
-        {
-            string accountId = "123123123";
-            string domain = DomainUtils.GetDomainFromAccountId(accountId);
-            Assert.AreEqual("laserfiche.com", domain);
-        }
-
-        [TestMethod]
-        public void GetDomainFromAccountId_CA()
-        {
-            string accountId = "1111111111";
-            string domain = DomainUtils.GetDomainFromAccountId(accountId);
-            Assert.AreEqual("laserfiche.ca", domain);
-        }
-
-        [TestMethod]
-        public void GetDomainFromAccountId_EU()
-        {
-            string accountId = "2222222222";
-            string domain = DomainUtils.GetDomainFromAccountId(accountId);
-            Assert.AreEqual("eu.laserfiche.com", domain);
-        }
-
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
-        [DataTestMethod]
-        [DataRow("")]
-        [DataRow("123")]
-        [DataRow("3333333333")]
-        [DataRow("123123123123")]
-        public void GetDomainFromAccountId_IncorrectAccountId(string accountId)
-        {
-            DomainUtils.GetDomainFromAccountId(accountId);
-        }
-
-        [TestMethod]
         public void GetOAuthBaseUri_Success()
         {
             string domain = "laserfiche.ca";


### PR DESCRIPTION
[GitHub Issue](https://github.com/Laserfiche/lf-api-client-core-dotnet/issues/52)
- Removed `System.ComponentModel.Annotation` dependency
- Lower `Newtonsoft.Json` version to v12.0.3
  - Apply the MaxDepth fixed mentioned in this post https://github.com/advisories/GHSA-5crp-9r3c-p9vr on the vulnerability in v12

Additional Changes
- Remove unused `GetDomainFromAccountId`. Equivalent PR was made in the js client library
  - https://github.com/Laserfiche/lf-api-client-core-js/pull/40
- Remove unnecessary dotnet targets