### PR TITLE
Update ApiException thrown error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.2.3"
+  VERSION_PREFIX: "1.3.0"
 
 jobs:
   build-n-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.3.0
+
+### Fixes
+- Fix the error message when an `ApiException` is thrown and use the `ProblemDetails.Title` if possible.
+- Add more properties to the `ProblemDetails` type to more accurately represent the response.
+- **[BREAKING]** Types `ApiException` and `ProblemDetails` have been moved to namespace `Laserfiche.Api.Client`.
+- **[BREAKING]** Property `ProblemDetails.AdditionalProperties` has been removed. Use property `ProblemDetails.Extensions` instead.
+- **[BREAKING]** Types of `ApiException<T>` has been removed. Use `ApiException` instead. The `ApiException` has a `ProblemDetails` property which may contain additional information.
+
 ## 1.2.3
 
 ### Fixes

--- a/apiserver-nswag.json
+++ b/apiserver-nswag.json
@@ -14,9 +14,12 @@
       "namespace": "Laserfiche.Api.Client.APIServer",
       "output": "src/APIServer/TokenClient.cs",
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
+      "excludedTypeNames": [ "ProblemDetails" ],
       "generateClientInterfaces": true,
       "generateDataAnnotations": false,
+      "generateExceptionClasses": false,
       "generateOptionalParameters": true,
+      "templateDirectory": "nswag",
       "useBaseUrl": false
     }
   }

--- a/nswag/Client.Class.ProcessResponse.liquid
+++ b/nswag/Client.Class.ProcessResponse.liquid
@@ -1,0 +1,72 @@
+{% if response.HasType -%}
+{%     if response.IsFile -%}
+{%         if response.IsSuccess -%}
+var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
+var fileResponse_ = new FileResponse(status_, headers_, responseStream_, {% if InjectHttpClient or DisposeHttpClient == false %}null{% else %}client_{% endif %}, response_);
+disposeClient_ = false; disposeResponse_ = false; // response and client are disposed by FileResponse
+return fileResponse_;
+{%         else -%}
+var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_, cancellationToken).ConfigureAwait(false);
+throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+{%         endif -%}
+{%     elsif response.IsPlainText -%}
+var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+var result_ = ({{ response.Type }})System.Convert.ChangeType(responseData_, typeof({{ response.Type }}));
+{%         if response.IsSuccess -%}
+{%             if operation.WrapResponse -%}
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, result_);
+{%             else -%}
+return result_;
+{%             endif -%}
+{%         else -%}
+throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, responseData_, headers_, result_, null);
+{%         endif -%}
+{%     else -%}
+var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(response_, headers_, cancellationToken).ConfigureAwait(false);
+{%         if response.IsNullable == false -%}
+if (objectResponse_.Object == null)
+{
+    throw new {{ ExceptionClass }}("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+}
+{%         endif -%}
+{%         if response.IsSuccess -%}
+{%             if operation.WrapResponse -%}
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, objectResponse_.Object);
+{%             else -%}
+return objectResponse_.Object;
+{%             endif -%}
+{%         endif -%}
+{%         if response.IsSuccess == false -%}
+{%             if response.InheritsExceptionSchema -%}
+var responseObject_ = objectResponse_.Object != null ? objectResponse_.Object : new {{ response.Type }}();
+responseObject_.Data.Add("HttpStatus", status_.ToString());
+responseObject_.Data.Add("HttpHeaders", headers_);
+responseObject_.Data.Add("HttpResponse", objectResponse_.Text);
+{%                 if WrapDtoExceptions -%}
+throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, responseObject_);
+{%                 else -%}
+throw responseObject_;
+{%                 endif -%}
+{%             else -%}
+throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+{%             endif -%}
+{%         endif -%}
+{%     endif -%}
+{% elsif response.IsSuccess -%}
+{%     if operation.HasResultType -%}
+{%         if operation.WrapResponse -%}
+return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
+{%         else -%}
+return {{ operation.UnwrappedResultDefaultValue }};
+{%         endif -%}
+{%     else -%}
+{%         if operation.WrapResponse -%}
+return new {{ ResponseClass }}(status_, headers_);
+{%         else -%}
+return;
+{%         endif -%}
+{%     endif -%}
+{% else -%}{% comment %} implied: `if !response.HasType` so just read it as text {% endcomment %}
+string responseText_ = ( response_.Content == null ) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, responseText_, headers_, null);
+{% endif %}

--- a/nswag/Client.Class.ProcessResponse.liquid
+++ b/nswag/Client.Class.ProcessResponse.liquid
@@ -26,7 +26,7 @@ var objectResponse_ = await ReadObjectResponseAsync<{{ response.Type }}>(respons
 {%         if response.IsNullable == false -%}
 if (objectResponse_.Object == null)
 {
-    throw new {{ ExceptionClass }}("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+    throw {{ ExceptionClass }}.Create(status_, headers_, null);
 }
 {%         endif -%}
 {%         if response.IsSuccess -%}
@@ -48,7 +48,7 @@ throw new {{ ExceptionClass }}("{{ response.ExceptionDescription }}", status_, o
 throw responseObject_;
 {%                 endif -%}
 {%             else -%}
-throw new {{ ExceptionClass }}<{{ response.Type }}>("{{ response.ExceptionDescription }}", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+throw {{ ExceptionClass }}.Create(status_, headers_, objectResponse_.Object, null);
 {%             endif -%}
 {%         endif -%}
 {%     endif -%}

--- a/nswag/Client.Class.ReadObjectResponse.liquid
+++ b/nswag/Client.Class.ReadObjectResponse.liquid
@@ -1,0 +1,60 @@
+﻿public bool ReadResponseAsString { get; set; }
+
+protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
+{
+    if (response == null || response.Content == null)
+    {
+{%- if GenerateNullableReferenceTypes -%}
+        return new ObjectResponseResult<T>(default(T)!, string.Empty);
+{%- else -%}
+        return new ObjectResponseResult<T>(default(T), string.Empty);
+{%- endif -%}
+    }
+
+    if (ReadResponseAsString)
+    {
+        var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        try
+        {
+            var typedBody = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.Deserialize{% else %}Newtonsoft.Json.JsonConvert.DeserializeObject{% endif %}<T>(responseText, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
+{%- if GenerateNullableReferenceTypes -%}
+            return new ObjectResponseResult<T>(typedBody!, responseText);
+{%- else -%}
+            return new ObjectResponseResult<T>(typedBody, responseText);
+{%- endif -%}
+        }
+        catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
+        {
+            var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, responseText, headers, exception);
+        }
+    }
+    else
+    {
+        try
+        {
+            using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+{%- if UseSystemTextJson -%}
+            {
+                var typedBody = await System.Text.Json.JsonSerializer.DeserializeAsync<T>(responseStream, {% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings, cancellationToken).ConfigureAwait(false);
+{%- else -%}
+            using (var streamReader = new System.IO.StreamReader(responseStream))
+            using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+            {
+                var serializer = Newtonsoft.Json.JsonSerializer.Create({% if UseRequestAndResponseSerializationSettings %}Response{% endif %}JsonSerializerSettings);
+                var typedBody = serializer.Deserialize<T>(jsonTextReader);
+{%- endif -%}
+{%- if GenerateNullableReferenceTypes -%}
+                return new ObjectResponseResult<T>(typedBody!, string.Empty);
+{%- else -%}
+                return new ObjectResponseResult<T>(typedBody, string.Empty);
+{%- endif -%}
+            }
+        }
+        catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
+        {
+            var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
+            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, string.Empty, headers, exception);
+        }
+    }
+}

--- a/nswag/Client.Class.ReadObjectResponse.liquid
+++ b/nswag/Client.Class.ReadObjectResponse.liquid
@@ -26,7 +26,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
         {
             var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
-            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, responseText, headers, exception);
+            throw {{ ExceptionClass }}.Create((int)response.StatusCode, headers, responseText, JsonSerializerSettings, exception);
         }
     }
     else
@@ -54,7 +54,7 @@ protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> Rea
         catch ({% if UseSystemTextJson %}System.Text.Json.JsonException{% else %}Newtonsoft.Json.JsonException{% endif %} exception)
         {
             var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
-            throw new {{ ExceptionClass }}(message, (int)response.StatusCode, string.Empty, headers, exception);
+            throw {{ ExceptionClass }}.Create((int)response.StatusCode, headers, exception);
         }
     }
 }

--- a/nswag/Client.Class.liquid
+++ b/nswag/Client.Class.liquid
@@ -1,0 +1,412 @@
+{% template Client.Class.Annotations %}
+[System.CodeDom.Compiler.GeneratedCode("NSwag", "{{ ToolchainVersion }}")]
+{{ ClientClassAccessModifier }} partial class {{ Class }} {% if HasBaseType %}: {% endif %}{% if HasBaseClass %}{{ BaseClass }}{% if GenerateClientInterfaces %}, {% endif %}{% endif %}{% if GenerateClientInterfaces %}I{{ Class }}{% endif %}
+{
+{% if UseBaseUrl and GenerateBaseUrlProperty -%}
+    private string _baseUrl = "{{ BaseUrl }}";
+{% endif -%}
+{% if InjectHttpClient -%}
+    private {{ HttpClientType }} _httpClient;
+{% endif -%}
+{% if UseRequestAndResponseSerializationSettings -%}
+    private System.Lazy<{{ JsonSerializerSettingsType }}> _requestSettings;
+    private System.Lazy<{{ JsonSerializerSettingsType }}> _responseSettings;
+{% else -%}
+    private System.Lazy<{{ JsonSerializerSettingsType }}> _settings;
+{% endif -%}
+
+{% if HasConfigurationClass -%}
+    public {{ Class }}({{ ConfigurationClass }} configuration{% if InjectHttpClient %}, {{ HttpClientType }} httpClient{% endif %}) : base(configuration)
+    {
+{%     if InjectHttpClient -%}
+        _httpClient = httpClient;
+{%     endif -%}
+{% elsif UseBaseUrl and HasBaseUrl == false %}
+    public {{ Class }}(string baseUrl{% if InjectHttpClient %}, {{ HttpClientType }} httpClient{% endif %})
+    {
+        BaseUrl = baseUrl;
+{%     if InjectHttpClient -%}
+        _httpClient = httpClient;
+{%     endif -%}
+{% elsif InjectHttpClient %}
+    public {{ Class }}({{ HttpClientType }} httpClient)
+    {
+        _httpClient = httpClient;
+{% else -%}
+    public {{ Class }}()
+    {
+{% endif -%}
+{% if UseRequestAndResponseSerializationSettings -%}
+        _requestSettings = new System.Lazy<{{ JsonSerializerSettingsType }}>(() => CreateSerializerSettings(true));
+        _responseSettings = new System.Lazy<{{ JsonSerializerSettingsType }}>(() => CreateSerializerSettings(false));
+{% else -%}
+        _settings = new System.Lazy<{{ JsonSerializerSettingsType }}>(CreateSerializerSettings);
+{% endif -%}
+        {% template Client.Class.Constructor %}
+    }
+
+    private {{ JsonSerializerSettingsType }} CreateSerializerSettings({% if UseRequestAndResponseSerializationSettings %}bool isRequest{% endif %})
+    {
+        var settings = {{ JsonSerializerParameterCode }};
+{% if UseSystemTextJson == false and SerializeTypeInformation -%}
+        settings.TypeNameHandling = Newtonsoft.Json.TypeNameHandling.Auto;
+{% endif -%}
+{% if UseSystemTextJson == true and JsonConvertersArrayCode contains "System.Text.Json.Serialization.JsonConverter[]" -%}
+        var converters = {{ JsonConvertersArrayCode }};
+        foreach(var converter in converters)
+            settings.Converters.Add(converter);
+{% endif -%}
+        UpdateJsonSerializerSettings(settings{% if UseRequestAndResponseSerializationSettings %}, isRequest{% endif %});
+        return settings;
+    }
+
+{% if UseBaseUrl and GenerateBaseUrlProperty -%}
+    public string BaseUrl
+    {
+        get { return _baseUrl; }
+        set { _baseUrl = value; }
+    }
+
+{% endif -%}
+{% if ExposeJsonSerializerSettings -%}
+{%     assign serializerSettingsAccessModifier = "public" %}
+{% else -%}
+{%     assign serializerSettingsAccessModifier = "protected" %}
+{% endif -%}
+{% if UseRequestAndResponseSerializationSettings -%}
+    {{ serializerSettingsAccessModifier }} {{ JsonSerializerSettingsType }} RequestJsonSerializerSettings { get { return _requestSettings.Value; } }
+    {{ serializerSettingsAccessModifier }} {{ JsonSerializerSettingsType }} ResponseJsonSerializerSettings { get { return _responseSettings.Value; } }
+{% else -%}
+    {{ serializerSettingsAccessModifier }} {{ JsonSerializerSettingsType }} JsonSerializerSettings { get { return _settings.Value; } }
+{% endif -%}
+
+{% if GenerateUpdateJsonSerializerSettingsMethod -%}
+{%     if UseRequestAndResponseSerializationSettings -%}
+    partial void UpdateJsonSerializerSettings({{ JsonSerializerSettingsType }} settings, bool isRequest);
+{%     else -%}
+    partial void UpdateJsonSerializerSettings({{ JsonSerializerSettingsType }} settings);
+{%     endif -%}
+{% endif -%}
+
+
+{% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods == false -%}
+    partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, string url);
+    partial void PrepareRequest({{ HttpClientType }} client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
+    partial void ProcessResponse({{ HttpClientType }} client, System.Net.Http.HttpResponseMessage response);
+{% endif -%}
+{% for operation in Operations %}
+{%     if GenerateOptionalParameters == false -%}
+    {% template Client.Method.Documentation %}
+    {% template Client.Method.Annotations %}
+    {{ operation.MethodAccessModifier }} virtual {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %})
+    {
+        return {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None);
+    }
+
+{%     endif -%}
+{%     if GenerateSyncMethods -%}
+    {% template Client.Method.Documentation %}
+    {% template Client.Method.Annotations %}
+    {{ operation.MethodAccessModifier }} virtual {{ operation.SyncResultType }} {{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}{% if parameter.IsLast == false %}, {% endif %}{% endfor %})
+    {
+        {% if operation.HasResult or operation.WrapResponse %}return {% endif %}System.Threading.Tasks.Task.Run(async () => await {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.VariableName }}, {% endfor %}System.Threading.CancellationToken.None)).GetAwaiter().GetResult();
+    }
+
+{%     endif -%}
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    {% template Client.Method.Documentation %}
+    {% template Client.Method.Annotations %}
+    {{ operation.MethodAccessModifier }} virtual async {{ operation.ResultType }} {{ operation.ActualOperationName }}Async({% for parameter in operation.Parameters %}{{ parameter.Type }} {{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %} = null{% endif %}, {% endfor %}System.Threading.CancellationToken cancellationToken{% if GenerateOptionalParameters %} = default(System.Threading.CancellationToken){% endif %})
+    {
+{%     for parameter in operation.PathParameters -%}
+{%         if parameter.IsNullable == false and parameter.IsRequired -%}
+        if ({{ parameter.VariableName }} == null)
+            throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+
+{%         endif -%}
+{%     endfor -%}
+{%     for parameter in operation.QueryParameters -%}
+{%         if parameter.IsNullable == false and parameter.IsRequired -%}
+        if ({{ parameter.VariableName }} == null)
+            throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+
+{%         endif -%}
+{%     endfor -%}
+{%     if operation.HasContent and operation.ContentParameter.IsRequired -%}
+        if ({{ operation.ContentParameter.VariableName }} == null)
+            throw new System.ArgumentNullException("{{ operation.ContentParameter.VariableName }}");
+
+{%     endif -%}
+        var urlBuilder_ = new System.Text.StringBuilder();
+        urlBuilder_.Append({% if UseBaseUrl %}BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/{% else %}"{% endif %}{{ operation.Path }}{% if operation.HasQueryParameters %}?{% endif %}");
+{%     for parameter in operation.PathParameters -%}
+{%         if parameter.IsOptional -%}
+        if ({{ parameter.VariableName }} != null)
+            {% template Client.Class.PathParameter %}
+        else
+            urlBuilder_.Replace("/{{ "{" }}{{ parameter.Name }}}", string.Empty);
+{%         else -%}
+        {% template Client.Class.PathParameter %}
+{%         endif -%}
+{%     endfor -%}
+{%     for parameter in operation.QueryParameters -%}
+{%         if parameter.IsOptional -%}
+        if ({{ parameter.VariableName }} != null)
+        {
+            {% template Client.Class.QueryParameter %}
+        }
+{%         else -%}
+        {% template Client.Class.QueryParameter %}
+{%         endif -%}
+{%     endfor -%}
+{%     if operation.HasQueryParameters -%}
+        urlBuilder_.Length--;
+{%     endif -%}
+
+{%     if InjectHttpClient -%}
+        var client_ = _httpClient;
+{%     elsif UseHttpClientCreationMethod -%}
+        var client_ = await CreateHttpClientAsync(cancellationToken).ConfigureAwait(false);
+{%     else -%}
+        var client_ = new {{ HttpClientType }}();
+{%     endif -%}
+{%     if InjectHttpClient == false and DisposeHttpClient -%}
+        var disposeClient_ = true;
+{%     else -%}
+        var disposeClient_ = false;
+{%     endif -%}
+        try
+        {
+{%     if UseHttpRequestMessageCreationMethod -%}
+            using (var request_ = await CreateHttpRequestMessageAsync(cancellationToken).ConfigureAwait(false))
+{%     else -%}
+            using (var request_ = new System.Net.Http.HttpRequestMessage())
+{%     endif -%}
+            {
+{%     for parameter in operation.HeaderParameters %}
+{%         if parameter.IsRequired -%}
+                if ({{ parameter.VariableName }} == null)
+                    throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+                {% template Client.Class.HeaderParameter %}
+{%         else -%}
+                if ({{ parameter.VariableName }} != null)
+                    {% template Client.Class.HeaderParameter %}
+{%         endif -%}
+{%     endfor -%}
+{%     if operation.HasContent -%}
+{%         if operation.HasBinaryBodyParameter -%}
+{%             if operation.ContentParameter.HasBinaryBodyWithMultipleMimeTypes -%}
+                var content_ = new System.Net.Http.StreamContent({{ operation.ContentParameter.VariableName }}.Data);
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse({{ operation.ContentParameter.VariableName }}.ContentType);
+{%             else -%}
+                var content_ = new System.Net.Http.StreamContent({{ operation.ContentParameter.VariableName }});
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%             endif -%}
+{%         elsif operation.HasXmlBodyParameter -%}
+                var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%         elsif operation.ConsumesFormUrlEncoded -%}
+                var json_ = Newtonsoft.Json.JsonConvert.SerializeObject({{ operation.ContentParameter.VariableName }}, _settings.Value);
+                var dictionary_ = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, string>>(json_, _settings.Value);
+                var content_ = new System.Net.Http.FormUrlEncodedContent(dictionary_);
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%         elsif operation.HasPlainTextBodyParameter -%}
+                var content_ = new System.Net.Http.StringContent({{ operation.ContentParameter.VariableName }});
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%         else -%}
+                var json_ = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.Serialize{% else %}Newtonsoft.Json.JsonConvert.SerializeObject{% endif %}({{ operation.ContentParameter.VariableName }}, {% if SerializeTypeInformation %}typeof({{ operation.ContentParameter.Type }}), {% endif %}{% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value);
+                var content_ = new System.Net.Http.StringContent(json_);
+                content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("{{ operation.Consumes }}");
+{%         endif -%}
+                request_.Content = content_;
+{%     else -%}
+{%         if operation.HasFormParameters -%}
+{%             if operation.ConsumesFormUrlEncoded -%}
+                var keyValues_ = new System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, string>>();
+{%                 for parameter in operation.FormParameters -%}
+{%                     if parameter.IsNullable -%}
+                if ({{ parameter.VariableName }} != null)
+{%                     else -%}
+                if ({{ parameter.VariableName }} == null)
+                    throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+                else
+{%                     endif -%}
+                    keyValues_.Add(new System.Collections.Generic.KeyValuePair<string, string>("{{ parameter.Name }}", ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)));
+{%                 endfor -%}
+                request_.Content = new System.Net.Http.FormUrlEncodedContent(keyValues_);
+{%             else -%}
+                var boundary_ = System.Guid.NewGuid().ToString();
+                var content_ = new System.Net.Http.MultipartFormDataContent(boundary_);
+                content_.Headers.Remove("Content-Type");
+                content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
+{%                 for parameter in operation.FormParameters %}
+{%                     if parameter.IsNullable -%}
+                if ({{ parameter.VariableName }} != null)
+{%                     else -%}
+                if ({{ parameter.VariableName }} == null)
+                    throw new System.ArgumentNullException("{{ parameter.VariableName }}");
+                else
+{%                     endif -%}
+                {
+{%                     if parameter.IsFile -%}
+{%                         if parameter.IsArray -%}
+                    foreach (var item_ in {{ parameter.VariableName }})
+                    {
+                        var content_{{ parameter.VariableName }}_ = new System.Net.Http.StreamContent(item_.Data);
+                        if (!string.IsNullOrEmpty(item_.ContentType))
+                            content_{{ parameter.VariableName }}_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(item_.ContentType);
+                        content_.Add(content_{{ parameter.VariableName }}_, "{{ parameter.Name }}", item_.FileName ?? "{{ parameter.Name }}");
+                    }
+{%                         else -%}
+                    var content_{{ parameter.VariableName }}_ = new System.Net.Http.StreamContent({{ parameter.VariableName }}.Data);
+                    if (!string.IsNullOrEmpty({{ parameter.VariableName }}.ContentType))
+                        content_{{ parameter.VariableName }}_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse({{ parameter.VariableName }}.ContentType);
+                    content_.Add(content_{{ parameter.VariableName }}_, "{{ parameter.Name }}", {{ parameter.VariableName }}.FileName ?? "{{ parameter.Name }}");
+{%                         endif -%}
+{%                     elsif parameter.IsArray -%}
+                    foreach (var item_ in {{ parameter.VariableName }})
+                    {
+                        content_.Add(new System.Net.Http.StringContent(ConvertToString(item_, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
+                    }
+{%                     elsif parameter.IsObject -%}
+                    var json_ = {% if UseSystemTextJson %}System.Text.Json.JsonSerializer.Serialize{% else %}Newtonsoft.Json.JsonConvert.SerializeObject{% endif %}({{ parameter.VariableName }}, {% if UseRequestAndResponseSerializationSettings %}_requestSettings{% else %}_settings{% endif %}.Value);
+                    content_.Add(new System.Net.Http.StringContent(json_), "{{ parameter.Name }}");
+{%                     else -%}
+                    content_.Add(new System.Net.Http.StringContent(ConvertToString({{ parameter.VariableName }}, System.Globalization.CultureInfo.InvariantCulture)), "{{ parameter.Name }}");
+{%                     endif -%}
+                }
+{%                 endfor -%}
+                request_.Content = content_;
+{%             endif -%}
+{%         elsif operation.IsGetOrDeleteOrHead == false -%}
+                request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "{{ operation.Produces }}");
+{%         endif -%}
+{%     endif -%}
+                request_.Method = new System.Net.Http.HttpMethod("{{ operation.HttpMethodUpper | upcase }}");
+{%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
+                request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("{{ operation.Produces }}"));
+{%     endif -%}
+
+{% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods %}
+                await PrepareRequestAsync(client_, request_, urlBuilder_, cancellationToken).ConfigureAwait(false);
+{% else -%}
+                PrepareRequest(client_, request_, urlBuilder_);
+{% endif -%}
+
+                var url_ = urlBuilder_.ToString();
+                request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+{% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods -%}
+                await PrepareRequestAsync(client_, request_, url_, cancellationToken).ConfigureAwait(false);
+{% else -%}
+                PrepareRequest(client_, request_, url_);
+{% endif -%}
+                {% template Client.Class.BeforeSend %}
+
+                var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                var disposeResponse_ = true;
+                try
+                {
+                    var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                    if (response_.Content != null && response_.Content.Headers != null)
+                    {
+                        foreach (var item_ in response_.Content.Headers)
+                            headers_[item_.Key] = item_.Value;
+                    }
+
+{% if GeneratePrepareRequestAndProcessResponseAsAsyncMethods %}
+                    await ProcessResponseAsync(client_, response_, cancellationToken).ConfigureAwait(false);
+{% else %}
+                    ProcessResponse(client_, response_);
+{% endif %}
+
+                    var status_ = (int)response_.StatusCode;
+{%     for response in operation.Responses -%}
+                    if (status_ == {{ response.StatusCode }}{% if response.CheckChunkedStatusCode %} || status_ == 206{% endif %})
+                    {
+                        {% template Client.Class.ProcessResponse %}
+                    }
+                    else
+{%     endfor -%}
+{%     if operation.HasDefaultResponse -%}
+{%         if operation.DefaultResponse.HasType -%}
+                    {
+{%             assign response = operation.DefaultResponse -%}
+                        {% template Client.Class.ProcessResponse %}
+                    }
+{%         elsif operation.HasSuccessResponse -%}
+                    {
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        throw new {{ ExceptionClass }}("{{ operation.DefaultResponse.ExceptionDescription }}", status_, responseData_, headers_, null);
+                    }
+{%        elsif operation.HasResultType -%}
+{%             if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" %}
+                    return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
+{%             else -%}
+                    return {{ operation.UnwrappedResultDefaultValue }};
+{%             endif -%}
+{%         elsif operation.WrapResponse -%}
+                    return new {{ ResponseClass }}(status_, headers_);
+{%         endif -%}
+{%     else -%}
+{%         if operation.HasSuccessResponse == false -%}
+{% comment -%}
+    If the success response has already been explicitely declared, there is no need for this default code (because handled above).
+    Otherwise, return default values on success because we don't want to throw on "unknown status code".
+    Success is always expected
+{%- endcomment %}
+                    if (status_ == 200 || status_ == 204)
+                    {
+{%             if operation.HasResultType -%}
+{%                 if operation.WrapResponse and operation.UnwrappedResultType != "FileResponse" %}
+                        return new {{ ResponseClass }}<{{ operation.UnwrappedResultType }}>(status_, headers_, {{ operation.UnwrappedResultDefaultValue }});
+{%                 else -%}
+                        return {{ operation.UnwrappedResultDefaultValue }};
+{%                 endif -%}
+{%             elsif operation.WrapResponse -%}
+                        return new {{ ResponseClass }}(status_, headers_);
+{%             else -%}{% comment %} This method isn't expected to return a value. Just return. {% endcomment %}
+                        return;
+{%             endif -%}
+                    }
+                    else
+{%         endif -%}
+                    {
+                        var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                    }
+{%     endif -%}
+                }
+                finally
+                {
+                    if (disposeResponse_)
+                        response_.Dispose();
+                }
+            }
+        }
+        finally
+        {
+            if (disposeClient_)
+                client_.Dispose();
+        }
+    }
+
+{% endfor %}
+    protected struct ObjectResponseResult<T>
+    {
+        public ObjectResponseResult(T responseObject, string responseText)
+        {
+            this.Object = responseObject;
+            this.Text = responseText;
+        }
+
+        public T Object { get; }
+
+        public string Text { get; }
+    }
+
+    {% template Client.Class.ReadObjectResponse %}
+
+    {% template Client.Class.ConvertToString %}
+    {% template Client.Class.Body %}
+}

--- a/nswag/Client.Class.liquid
+++ b/nswag/Client.Class.liquid
@@ -373,7 +373,7 @@
 {%         endif -%}
                     {
                         var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        throw new {{ ExceptionClass }}("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        throw {{ ExceptionClass }}.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
                     }
 {%     endif -%}
                 }

--- a/oauth-nswag.json
+++ b/oauth-nswag.json
@@ -14,9 +14,12 @@
       "namespace": "Laserfiche.Api.Client.OAuth",
       "output": "src/OAuth/OAuthClient.cs",
       "operationGenerationMode": "MultipleClientsFromFirstTagAndPathSegments",
+      "excludedTypeNames": [ "ProblemDetails" ],
       "generateClientInterfaces": true,
       "generateDataAnnotations": false,
+      "generateExceptionClasses": false,
       "generateOptionalParameters": true,
+      "templateDirectory": "nswag",
       "useBaseUrl": false
     }
   }

--- a/src/APIServer/TokenClient.cs
+++ b/src/APIServer/TokenClient.cs
@@ -122,7 +122,7 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<SessionKeyInfo>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
                             return objectResponse_.Object;
                         }
@@ -132,9 +132,9 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Invalid or bad request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 401)
@@ -142,9 +142,9 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 403)
@@ -152,9 +152,9 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 404)
@@ -162,9 +162,9 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 429)
@@ -172,14 +172,14 @@ namespace Laserfiche.Api.Client.APIServer
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("Rate limit is reached.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                            throw ApiException.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
                         }
                     }
                     finally
@@ -229,7 +229,7 @@ namespace Laserfiche.Api.Client.APIServer
                 catch (Newtonsoft.Json.JsonException exception)
                 {
                     var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
-                    throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+                    throw ApiException.Create((int)response.StatusCode, headers, responseText, JsonSerializerSettings, exception);
                 }
             }
             else
@@ -248,7 +248,7 @@ namespace Laserfiche.Api.Client.APIServer
                 catch (Newtonsoft.Json.JsonException exception)
                 {
                     var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
-                    throw new ApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+                    throw ApiException.Create((int)response.StatusCode, headers, exception);
                 }
             }
         }
@@ -300,38 +300,6 @@ namespace Laserfiche.Api.Client.APIServer
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.16.1.0 (NJsonSchema v10.7.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class ProblemDetails
-    {
-        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Type { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Title { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? Status { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Detail { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Instance { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("extensions", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.Generic.IDictionary<string, object> Extensions { get; set; }
-
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        [Newtonsoft.Json.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.16.1.0 (NJsonSchema v10.7.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class SessionKeyInfo
     {
         /// <summary>
@@ -377,42 +345,6 @@ namespace Laserfiche.Api.Client.APIServer
 
     }
 
-
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.16.1.0 (NJsonSchema v10.7.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class ApiException : System.Exception
-    {
-        public int StatusCode { get; private set; }
-
-        public string Response { get; private set; }
-
-        public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
-
-        public ApiException(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException)
-            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + ((response == null) ? "(null)" : response.Substring(0, response.Length >= 512 ? 512 : response.Length)), innerException)
-        {
-            StatusCode = statusCode;
-            Response = response;
-            Headers = headers;
-        }
-
-        public override string ToString()
-        {
-            return string.Format("HTTP Response: \n\n{0}\n\n{1}", Response, base.ToString());
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.16.1.0 (NJsonSchema v10.7.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class ApiException<TResult> : ApiException
-    {
-        public TResult Result { get; private set; }
-
-        public ApiException(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException)
-            : base(message, statusCode, response, headers, innerException)
-        {
-            Result = result;
-        }
-    }
 
 }
 

--- a/src/ApiException.cs
+++ b/src/ApiException.cs
@@ -1,0 +1,98 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Laserfiche.Api.Client
+{
+    public partial class ApiException : Exception
+    {
+        public const string OPERATION_ID_HEADER = "X-RequestId";
+
+        /// <summary>
+        /// The API status code.
+        /// </summary>
+        public int StatusCode { get; private set; }
+
+        /// <summary>
+        /// The API error details.
+        /// </summary>
+        public ProblemDetails ProblemDetails { get; private set; }
+
+        /// <summary>
+        /// The API response headers.
+        /// </summary>
+        public IReadOnlyDictionary<string, IEnumerable<string>> Headers { get; private set; }
+
+        public ApiException(string message, int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, ProblemDetails problemDetails, Exception innerException)
+            : base(message, innerException)
+        {
+            StatusCode = statusCode;
+            Headers = headers;
+            ProblemDetails = problemDetails;
+        }
+
+        /// <summary>
+        /// Create an <see cref="ApiException"/>. Will try to deserialize the <paramref name="response"/> to a <see cref="Client.ProblemDetails"/>.
+        /// </summary>
+        /// <param name="statusCode">The response status code.</param>
+        /// <param name="headers">The response headers.</param>
+        /// <param name="response">The response body.</param>
+        /// <param name="jsonSerializerSettings">The json serializer settings used to deserialize the response.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <returns></returns>
+        public static ApiException Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, string response, JsonSerializerSettings jsonSerializerSettings, Exception innerException)
+        {
+            if (!string.IsNullOrWhiteSpace(response))
+            {
+                try
+                {
+                    ProblemDetails problemDetails = JsonConvert.DeserializeObject<ProblemDetails>(response, jsonSerializerSettings);
+                    return Create(statusCode, headers, problemDetails, innerException);
+                }
+                catch
+                {
+                    // fail to deserialize to ProblemDetails silently
+                }
+            }
+
+            return Create(statusCode, headers, innerException);
+        }
+
+        /// <summary>
+        /// Create an <see cref="ApiException"/> with a <see cref="Client.ProblemDetails"/>.
+        /// </summary>
+        /// <param name="statusCode">The response status code.</param>
+        /// <param name="headers">The response headers.</param>
+        /// <param name="problemDetails">The <see cref="Client.ProblemDetails"/> response.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <returns></returns>
+        public static ApiException Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, ProblemDetails problemDetails, Exception innerException)
+        {
+            if (problemDetails == null)
+            {
+                return Create(statusCode, headers, innerException);
+            }
+
+            return new ApiException(problemDetails.Title, statusCode, headers, problemDetails, innerException);
+        }
+
+        /// <summary>
+        /// Create an <see cref="ApiException"/>.
+        /// </summary>
+        /// <param name="statusCode">The response status code.</param>
+        /// <param name="headers">The response headers.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <returns></returns>
+        public static ApiException Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, Exception innerException)
+        {
+            ProblemDetails problemDetails = new ProblemDetails()
+            {
+                Title = $"HTTP status code {statusCode}.",
+                Status = statusCode,
+                OperationId = headers?.TryGetValue(OPERATION_ID_HEADER, out IEnumerable<string> operationIdHeader) == true ? operationIdHeader.FirstOrDefault() : null,
+            };
+            return Create(statusCode, headers, problemDetails, innerException);
+        }
+    }
+}

--- a/src/ApiException.cs
+++ b/src/ApiException.cs
@@ -1,14 +1,11 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Laserfiche.Api.Client
 {
     public partial class ApiException : Exception
     {
-        public const string OPERATION_ID_HEADER = "X-RequestId";
-
         /// <summary>
         /// The API status code.
         /// </summary>
@@ -86,12 +83,7 @@ namespace Laserfiche.Api.Client
         /// <returns></returns>
         public static ApiException Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, Exception innerException)
         {
-            ProblemDetails problemDetails = new ProblemDetails()
-            {
-                Title = $"HTTP status code {statusCode}.",
-                Status = statusCode,
-                OperationId = headers?.TryGetValue(OPERATION_ID_HEADER, out IEnumerable<string> operationIdHeader) == true ? operationIdHeader.FirstOrDefault() : null,
-            };
+            ProblemDetails problemDetails = ProblemDetails.Create(statusCode, headers);
             return Create(statusCode, headers, problemDetails, innerException);
         }
     }

--- a/src/HttpHandlers/UsernamePasswordHandler.cs
+++ b/src/HttpHandlers/UsernamePasswordHandler.cs
@@ -27,10 +27,13 @@ namespace Laserfiche.Api.Client.HttpHandlers
 
         internal UsernamePasswordHandler(string repoId, string username, string password, string baseUrl, ITokenClient client)
         {
-            _username = username;
-            _password = password;
+            if (baseUrl == null)
+                throw new ArgumentNullException(nameof(baseUrl));
+
+            _username = username ?? throw new ArgumentNullException(nameof(username));
+            _password = password ?? throw new ArgumentNullException(nameof(password));
+            _repoId = repoId ?? throw new ArgumentNullException(nameof(repoId));
             _baseUrl = baseUrl.TrimEnd('/') + "/";
-            _repoId = repoId;
 
             _request = new CreateConnectionRequest
             {

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -6,8 +6,8 @@
     <Authors>Laserfiche</Authors>
     <Company>Laserfiche</Company>
     <Version>1.3.0</Version>
-    <AssemblyVersion>1.3.0</AssemblyVersion>
-    <FileVersion>1.3.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
     <PackageProjectUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>Laserfiche OAuth OAuth2 Authentication Authorization</PackageTags>

--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -5,9 +5,9 @@
     <PackageId>Laserfiche.Api.Client.Core</PackageId>
     <Authors>Laserfiche</Authors>
     <Company>Laserfiche</Company>
-    <Version>1.2.3</Version>
-    <AssemblyVersion>1.2.3.0</AssemblyVersion>
-    <FileVersion>1.2.3.0</FileVersion>
+    <Version>1.3.0</Version>
+    <AssemblyVersion>1.3.0</AssemblyVersion>
+    <FileVersion>1.3.0</FileVersion>
     <PackageProjectUrl>https://github.com/Laserfiche/lf-api-client-core-dotnet</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>Laserfiche OAuth OAuth2 Authentication Authorization</PackageTags>

--- a/src/OAuth/OAuthClient.cs
+++ b/src/OAuth/OAuthClient.cs
@@ -116,7 +116,7 @@ namespace Laserfiche.Api.Client.OAuth
                             var objectResponse_ = await ReadObjectResponseAsync<GetAccessTokenResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
                             return objectResponse_.Object;
                         }
@@ -126,9 +126,9 @@ namespace Laserfiche.Api.Client.OAuth
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 401)
@@ -136,9 +136,9 @@ namespace Laserfiche.Api.Client.OAuth
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         if (status_ == 403)
@@ -146,14 +146,14 @@ namespace Laserfiche.Api.Client.OAuth
                             var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                             if (objectResponse_.Object == null)
                             {
-                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                                throw ApiException.Create(status_, headers_, null);
                             }
-                            throw new ApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                            throw ApiException.Create(status_, headers_, objectResponse_.Object, null);
                         }
                         else
                         {
                             var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                            throw ApiException.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
                         }
                     }
                     finally
@@ -203,7 +203,7 @@ namespace Laserfiche.Api.Client.OAuth
                 catch (Newtonsoft.Json.JsonException exception)
                 {
                     var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
-                    throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+                    throw ApiException.Create((int)response.StatusCode, headers, responseText, JsonSerializerSettings, exception);
                 }
             }
             else
@@ -222,7 +222,7 @@ namespace Laserfiche.Api.Client.OAuth
                 catch (Newtonsoft.Json.JsonException exception)
                 {
                     var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
-                    throw new ApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+                    throw ApiException.Create((int)response.StatusCode, headers, exception);
                 }
             }
         }
@@ -271,35 +271,6 @@ namespace Laserfiche.Api.Client.OAuth
             var result = System.Convert.ToString(value, cultureInfo);
             return result == null ? "" : result;
         }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class ProblemDetails
-    {
-        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Type { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Title { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? Status { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Detail { get; set; }
-
-        [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Instance { get; set; }
-
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
-
-        [Newtonsoft.Json.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> AdditionalProperties
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
-
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
@@ -366,42 +337,6 @@ namespace Laserfiche.Api.Client.OAuth
 
     }
 
-
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class ApiException : System.Exception
-    {
-        public int StatusCode { get; private set; }
-
-        public string Response { get; private set; }
-
-        public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
-
-        public ApiException(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException)
-            : base(message + "\n\nStatus: " + statusCode + "\nResponse: \n" + ((response == null) ? "(null)" : response.Substring(0, response.Length >= 512 ? 512 : response.Length)), innerException)
-        {
-            StatusCode = statusCode;
-            Response = response;
-            Headers = headers;
-        }
-
-        public override string ToString()
-        {
-            return string.Format("HTTP Response: \n\n{0}\n\n{1}", Response, base.ToString());
-        }
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class ApiException<TResult> : ApiException
-    {
-        public TResult Result { get; private set; }
-
-        public ApiException(string message, int statusCode, string response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException)
-            : base(message, statusCode, response, headers, innerException)
-        {
-            Result = result;
-        }
-    }
 
 }
 

--- a/src/ProblemDetails.cs
+++ b/src/ProblemDetails.cs
@@ -1,76 +1,90 @@
-﻿namespace Laserfiche.Api.Client
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Laserfiche.Api.Client
 {
     /// <summary>
     /// A machine-readable format for specifying errors in HTTP API responses based on https://tools.ietf.org/html/rfc7807.
     /// </summary>
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial class ProblemDetails
     {
+        internal const string OPERATION_ID_HEADER = "X-RequestId";
+
         /// <summary>
         /// The problem type.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("type", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string Type { get; set; }
 
         /// <summary>
         /// A short, human-readable summary of the problem type.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Always)]
+        [JsonProperty("title", Required = Required.Always)]
         public string Title { get; set; }
 
         /// <summary>
         /// The HTTP status code.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Always)]
+        [JsonProperty("status", Required = Required.Always)]
         public int Status { get; set; }
 
         /// <summary>
         /// A human-readable explanation specific to this occurrence of the problem.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("detail", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string Detail { get; set; }
 
         /// <summary>
         /// A URI reference that identifies the specific occurrence of the problem.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("instance", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string Instance { get; set; }
 
         /// <summary>
         /// The operation id.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("operationId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("operationId", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string OperationId { get; set; }
 
         /// <summary>
         /// The error source.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("errorSource", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("errorSource", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string ErrorSource { get; set; }
 
         /// <summary>
         /// The error code.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("errorCode", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("errorCode", Required = Required.DisallowNull, NullValueHandling = NullValueHandling.Ignore)]
         public int ErrorCode { get; set; }
 
         /// <summary>
         /// The trace id.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty("traceId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [JsonProperty("traceId", Required = Required.Default, NullValueHandling = NullValueHandling.Ignore)]
         public string TraceId { get; set; }
-
-        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
 
         /// <summary>
         /// The extension members.
         /// </summary>
-        [Newtonsoft.Json.JsonExtensionData]
-        public System.Collections.Generic.IDictionary<string, object> Extensions
-        {
-            get { return _additionalProperties; }
-            set { _additionalProperties = value; }
-        }
+        [JsonExtensionData]
+        public IDictionary<string, object> Extensions { get; set; } = new Dictionary<string, object>();
 
+        /// <summary>
+        /// Create a minimal <see cref="ProblemDetails"/> using HTTP response information.
+        /// </summary>
+        /// <param name="statusCode">The response status code.</param>
+        /// <param name="headers">The response headers.</param>
+        /// <returns></returns>
+        public static ProblemDetails Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers)
+        {
+            return new ProblemDetails()
+            {
+                Title = $"HTTP status code {statusCode}.",
+                Status = statusCode,
+                OperationId = headers?.TryGetValue(OPERATION_ID_HEADER, out IEnumerable<string> operationIdHeader) == true ? operationIdHeader.FirstOrDefault() : null,
+            };
+        }
     }
 }

--- a/src/ProblemDetails.cs
+++ b/src/ProblemDetails.cs
@@ -1,0 +1,76 @@
+﻿namespace Laserfiche.Api.Client
+{
+    /// <summary>
+    /// A machine-readable format for specifying errors in HTTP API responses based on https://tools.ietf.org/html/rfc7807.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class ProblemDetails
+    {
+        /// <summary>
+        /// The problem type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// A short, human-readable summary of the problem type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("title", Required = Newtonsoft.Json.Required.Always)]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.Always)]
+        public int Status { get; set; }
+
+        /// <summary>
+        /// A human-readable explanation specific to this occurrence of the problem.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("detail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Detail { get; set; }
+
+        /// <summary>
+        /// A URI reference that identifies the specific occurrence of the problem.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("instance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Instance { get; set; }
+
+        /// <summary>
+        /// The operation id.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("operationId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string OperationId { get; set; }
+
+        /// <summary>
+        /// The error source.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("errorSource", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ErrorSource { get; set; }
+
+        /// <summary>
+        /// The error code.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("errorCode", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int ErrorCode { get; set; }
+
+        /// <summary>
+        /// The trace id.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("traceId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string TraceId { get; set; }
+
+        private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
+
+        /// <summary>
+        /// The extension members.
+        /// </summary>
+        [Newtonsoft.Json.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, object> Extensions
+        {
+            get { return _additionalProperties; }
+            set { _additionalProperties = value; }
+        }
+
+    }
+}

--- a/tests/integration/OAuthClientCredentialsHandlerTests.cs
+++ b/tests/integration/OAuthClientCredentialsHandlerTests.cs
@@ -40,6 +40,23 @@ namespace Laserfiche.Api.Client.IntegrationTest
             Assert.AreEqual(AccessKey.Domain, result2.RegionalDomain);
         }
 
+        [TestMethod]
+        public async Task BeforeSendAsync_FailedAuthentication_ThrowsException()
+        {
+            var httpRequestHandler = new OAuthClientCredentialsHandler("a wrong service principal key", AccessKey);
+            using var request = new System.Net.Http.HttpRequestMessage();
+
+            var exception = await Assert.ThrowsExceptionAsync<ApiException>(async () => await httpRequestHandler.BeforeSendAsync(request, default));
+
+            // Expect the retrieval of access token to fail due to incorrect service principal key
+            Assert.AreEqual(401, exception.ProblemDetails.Status);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.IsNotNull(exception.ProblemDetails.Title);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.IsNotNull(exception.ProblemDetails.Type);
+            Assert.IsNotNull(exception.ProblemDetails.OperationId);
+        }
+
         [DataTestMethod]
         [DataRow(HttpStatusCode.OK)]
         [DataRow(HttpStatusCode.Forbidden)]

--- a/tests/integration/TokenClientTests.cs
+++ b/tests/integration/TokenClientTests.cs
@@ -44,7 +44,13 @@ namespace Laserfiche.Api.Client.IntegrationTest
             TokenClient client = new(AccessKey.Domain);
 
             // Expect the retrieval of access token to fail due to incorrect service principal key
-            await Assert.ThrowsExceptionAsync<ApiException<ProblemDetails>>(async () => await client.GetAccessTokenFromServicePrincipalAsync("a wrong service principal key", AccessKey));
+            var exception = await Assert.ThrowsExceptionAsync<ApiException>(async () => await client.GetAccessTokenFromServicePrincipalAsync("a wrong service principal key", AccessKey));
+            Assert.AreEqual(401, exception.ProblemDetails.Status);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.IsNotNull(exception.ProblemDetails.Title);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.IsNotNull(exception.ProblemDetails.Type);
+            Assert.IsNotNull(exception.ProblemDetails.OperationId);
         }
     }
 }

--- a/tests/integration/UsernamePasswordHandlerTest.cs
+++ b/tests/integration/UsernamePasswordHandlerTest.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Laserfiche.Api.Client.HttpHandlers;
-using System;
+﻿using Laserfiche.Api.Client.HttpHandlers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
-using Laserfiche.Api.Client.APIServer;
-using System.Net;
+using System.Threading.Tasks;
 
 namespace Laserfiche.Api.Client.IntegrationTest
 {
@@ -61,10 +59,13 @@ namespace Laserfiche.Api.Client.IntegrationTest
             using var request = new HttpRequestMessage();
 
             // Assert
-            var ex = await Assert.ThrowsExceptionAsync<ApiException<ProblemDetails>>(() => _httpRequestHandler.BeforeSendAsync(request, new CancellationToken()));
-            Assert.AreEqual((int)status, ex.Result.Status);
-            Assert.IsNotNull(ex.Result.Type);
-            Assert.IsNotNull(ex.Result.Title);
+            var ex = await Assert.ThrowsExceptionAsync<ApiException>(() => _httpRequestHandler.BeforeSendAsync(request, new CancellationToken()));
+            Assert.AreEqual((int)status, ex.ProblemDetails.Status);
+            Assert.AreEqual(ex.ProblemDetails.Status, ex.StatusCode);
+            Assert.IsNotNull(ex.ProblemDetails.Type);
+            Assert.IsNotNull(ex.ProblemDetails.Title);
+            Assert.AreEqual(ex.ProblemDetails.Title, ex.Message);
+            Assert.IsNotNull(ex.ProblemDetails.OperationId);
         }
 
         private static IEnumerable<object[]> GetInvalidCredentials()

--- a/tests/unit/ApiExceptionTests.cs
+++ b/tests/unit/ApiExceptionTests.cs
@@ -65,7 +65,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
 
             ApiException exception = ApiException.Create(statusCode, headers, null);
@@ -88,7 +88,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             Exception innerException = new Exception("An error occurred.");
 
@@ -112,7 +112,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             ProblemDetails problemDetails = new ProblemDetails()
             {
@@ -154,7 +154,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             ProblemDetails problemDetails = null;
             Exception innerException = new Exception("An error occurred.");
@@ -180,7 +180,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string extensionsKey = "key";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             ProblemDetails problemDetails = new ProblemDetails()
             {
@@ -226,7 +226,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             Exception innerException = new Exception("An error occurred.");
 
@@ -250,7 +250,7 @@ namespace Laserfiche.Api.Client.UnitTest
             string operationId = "123456789";
             var headers = new Dictionary<string, IEnumerable<string>>()
             {
-                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
             var responseString = JsonConvert.SerializeObject(new Exception("An error occured."));
             Exception innerException = new Exception("An error occurred.");

--- a/tests/unit/ApiExceptionTests.cs
+++ b/tests/unit/ApiExceptionTests.cs
@@ -1,0 +1,271 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Laserfiche.Api.Client.UnitTest
+{
+    [TestClass]
+    public class ApiExceptionTests
+    {
+        private void AssertNullProblemDetailsOptionalProperties(ProblemDetails problemDetails)
+        {
+            Assert.IsNull(problemDetails.Type);
+            Assert.IsNull(problemDetails.Detail);
+            Assert.IsNull(problemDetails.Instance);
+            Assert.AreEqual(default, problemDetails.ErrorCode);
+            Assert.IsNull(problemDetails.ErrorSource);
+            Assert.IsNull(problemDetails.TraceId);
+        }
+
+        [TestMethod]
+        public void Create_WithNullHeaders_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+
+            ApiException exception = ApiException.Create(statusCode, null, null);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.IsNull(exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.IsNull(exception.Headers);
+            Assert.IsNull(exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithoutOperationIdHeader_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                ["Content-Type"] = new List<string>() { "application/json" }
+            };
+
+            ApiException exception = ApiException.Create(statusCode, headers, null);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.IsNull(exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.IsNull(exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithOperationIdHeader_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+
+            ApiException exception = ApiException.Create(statusCode, headers, null);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.AreEqual(operationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.IsNull(exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithInnerException_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, innerException);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.AreEqual(operationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithProblemDetails_ExceptionHasFullProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            ProblemDetails problemDetails = new ProblemDetails()
+            {
+                Title = "An error occurred.",
+                Type = "ErrorType",
+                Detail = "Detail",
+                Status = statusCode,
+                Instance = "Instance",
+                OperationId = operationId,
+                ErrorCode = 123,
+                ErrorSource = "ErrorSource",
+                TraceId = "TraceId",
+                Extensions = new Dictionary<string, object>() { ["key"] = "value" }
+            };
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, problemDetails, innerException);
+
+            Assert.AreEqual(problemDetails.Title, exception.ProblemDetails.Title);
+            Assert.AreEqual(problemDetails.Type, exception.ProblemDetails.Type);
+            Assert.AreEqual(problemDetails.Detail, exception.ProblemDetails.Detail);
+            Assert.AreEqual(problemDetails.Status, exception.ProblemDetails.Status);
+            Assert.AreEqual(problemDetails.Instance, exception.ProblemDetails.Instance);
+            Assert.AreEqual(problemDetails.OperationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(problemDetails.ErrorCode, exception.ProblemDetails.ErrorCode);
+            Assert.AreEqual(problemDetails.ErrorSource, exception.ProblemDetails.ErrorSource);
+            Assert.AreEqual(problemDetails.TraceId, exception.ProblemDetails.TraceId);
+            Assert.AreEqual(problemDetails.Extensions, exception.ProblemDetails.Extensions);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+
+        [TestMethod]
+        public void Create_WithNullProblemDetails_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            ProblemDetails problemDetails = null;
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, problemDetails, innerException);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.AreEqual(operationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithResponseString_ResponseStringIsProblemDetails_ExceptionHasFullProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            string extensionsKey = "key";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            ProblemDetails problemDetails = new ProblemDetails()
+            {
+                Title = "An error occurred.",
+                Type = "ErrorType",
+                Detail = "Detail",
+                Status = statusCode,
+                Instance = "Instance",
+                OperationId = operationId,
+                ErrorCode = 123,
+                ErrorSource = "ErrorSource",
+                TraceId = "TraceId",
+                Extensions = new Dictionary<string, object>() { [extensionsKey] = "value" }
+            };
+            string problemDetailsResponseString = JsonConvert.SerializeObject(problemDetails);
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, problemDetailsResponseString, null, innerException);
+
+            Assert.AreEqual(problemDetails.Title, exception.ProblemDetails.Title);
+            Assert.AreEqual(problemDetails.Type, exception.ProblemDetails.Type);
+            Assert.AreEqual(problemDetails.Detail, exception.ProblemDetails.Detail);
+            Assert.AreEqual(problemDetails.Status, exception.ProblemDetails.Status);
+            Assert.AreEqual(problemDetails.Instance, exception.ProblemDetails.Instance);
+            Assert.AreEqual(problemDetails.OperationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(problemDetails.ErrorCode, exception.ProblemDetails.ErrorCode);
+            Assert.AreEqual(problemDetails.ErrorSource, exception.ProblemDetails.ErrorSource);
+            Assert.AreEqual(problemDetails.TraceId, exception.ProblemDetails.TraceId);
+            Assert.AreEqual(problemDetails.Extensions.Count, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(problemDetails.Extensions[extensionsKey], exception.ProblemDetails.Extensions[extensionsKey]);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow("  ")]
+        public void Create_WithResponseString_ResponseStringIsEmpty_ExceptionHasMinimalProblemDetails(string responseString)
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, responseString, null, innerException);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.AreEqual(operationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+
+        [TestMethod]
+        public void Create_WithResponseString_ResponseStringIsNotProblemDetails_ExceptionHasMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ApiException.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+            var responseString = JsonConvert.SerializeObject(new Exception("An error occured."));
+            Exception innerException = new Exception("An error occurred.");
+
+            ApiException exception = ApiException.Create(statusCode, headers, responseString, null, innerException);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
+            Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
+            Assert.AreEqual(operationId, exception.ProblemDetails.OperationId);
+            Assert.AreEqual(0, exception.ProblemDetails.Extensions.Count);
+            Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);
+            Assert.AreEqual(exception.ProblemDetails.Title, exception.Message);
+            Assert.AreEqual(headers, exception.Headers);
+            Assert.AreEqual(innerException, exception.InnerException);
+            AssertNullProblemDetailsOptionalProperties(exception.ProblemDetails);
+        }
+    }
+}

--- a/tests/unit/ProblemDetailsTests.cs
+++ b/tests/unit/ProblemDetailsTests.cs
@@ -1,11 +1,55 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Laserfiche.Api.Client.UnitTest
 {
     [TestClass]
     public class ProblemDetailsTests
     {
+        [TestMethod]
+        public void Create_ReturnMinimalProblemDetails()
+        {
+            int statusCode = 400;
+            string operationId = "123456789";
+            var headers = new Dictionary<string, IEnumerable<string>>()
+            {
+                [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
+            };
+
+            ProblemDetails result = ProblemDetails.Create(statusCode, headers);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", result.Title);
+            Assert.AreEqual(statusCode, result.Status);
+            Assert.AreEqual(operationId, result.OperationId);
+            Assert.IsNull(result.Type);
+            Assert.IsNull(result.Instance);
+            Assert.IsNull(result.Detail);
+            Assert.IsNull(result.ErrorSource);
+            Assert.IsNull(result.TraceId);
+            Assert.AreEqual(default, result.ErrorCode);
+            Assert.AreEqual(0, result.Extensions.Count);
+        }
+
+        [TestMethod]
+        public void Create_NullHeaders_ReturnMinimalProblemDetails_NoOperationId()
+        {
+            int statusCode = 400;
+
+            ProblemDetails result = ProblemDetails.Create(statusCode, null);
+
+            Assert.AreEqual($"HTTP status code {statusCode}.", result.Title);
+            Assert.AreEqual(statusCode, result.Status);
+            Assert.IsNull(result.OperationId);
+            Assert.IsNull(result.Type);
+            Assert.IsNull(result.Instance);
+            Assert.IsNull(result.Detail);
+            Assert.IsNull(result.ErrorSource);
+            Assert.IsNull(result.TraceId);
+            Assert.AreEqual(default, result.ErrorCode);
+            Assert.AreEqual(0, result.Extensions.Count);
+        }
+
         [TestMethod]
         public void Deserialize_StringIsProblemDetailsWithExtensions()
         {

--- a/tests/unit/ProblemDetailsTests.cs
+++ b/tests/unit/ProblemDetailsTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Laserfiche.Api.Client.UnitTest
+{
+    [TestClass]
+    public class ProblemDetailsTests
+    {
+        [TestMethod]
+        public void Deserialize_StringIsProblemDetailsWithExtensions()
+        {
+            var mockProblemDetails = new MockProblemDetails()
+            {
+                Title = "An error occurred.",
+                Status = 400,
+                Description = "a description extension property"
+            };
+            var serializedObject = JsonConvert.SerializeObject(mockProblemDetails);
+
+            var result = JsonConvert.DeserializeObject<ProblemDetails>(serializedObject);
+
+            Assert.AreEqual(mockProblemDetails.Title, result.Title);
+            Assert.AreEqual(mockProblemDetails.Status, result.Status);
+            Assert.AreEqual(1, result.Extensions.Count);
+            Assert.AreEqual(mockProblemDetails.Description, result.Extensions[nameof(MockProblemDetails.Description)]);
+        }
+
+        [TestMethod]
+        public void Deserialize_StringNotProblemDetails_ThrowsException()
+        {
+            var obj = new Student()
+            {
+                Id = 1,
+                Name = "John",
+            };
+            var serializedObject = JsonConvert.SerializeObject(obj);
+
+            Assert.ThrowsException<JsonSerializationException>(() => JsonConvert.DeserializeObject<ProblemDetails>(serializedObject));
+        }
+
+        private class Student
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class MockProblemDetails
+        {
+            public int Status { get; set; }
+            public string Title { get; set; }
+            public string Description { get; set; }
+        }
+    }
+}

--- a/tests/unit/UsernamePasswordHandlerTests.cs
+++ b/tests/unit/UsernamePasswordHandlerTests.cs
@@ -75,19 +75,20 @@ namespace Laserfiche.Api.Client.UnitTest
             int status = 401;
 
             Mock<ITokenClient> tokenClientMock = new();
-            tokenClientMock.Setup(mock => mock.TokenAsync(It.IsAny<string>(), It.IsAny<CreateConnectionRequest>(), It.IsAny<CancellationToken>())).Throws(new ApiException<ProblemDetails>(title, status, null, null, new ProblemDetails
+            var problemDetails = new ProblemDetails
             {
                 Type = type,
                 Title = title,
                 Status = status
-            }, null));
+            };
+            tokenClientMock.Setup(mock => mock.TokenAsync(It.IsAny<string>(), It.IsAny<CreateConnectionRequest>(), It.IsAny<CancellationToken>())).Throws(ApiException.Create(status, null, problemDetails, null));
             _handler = new UsernamePasswordHandler(_repoId, _username, _password, _baseUrl, tokenClientMock.Object);
 
             // Assert
-            var ex = await Assert.ThrowsExceptionAsync<ApiException<ProblemDetails>>(()=>_handler.BeforeSendAsync(_request, new CancellationToken()));
-            Assert.AreEqual(type, ex.Result.Type);
-            Assert.AreEqual(title, ex.Result.Title);
-            Assert.AreEqual(status, ex.Result.Status);
+            var ex = await Assert.ThrowsExceptionAsync<ApiException>(()=>_handler.BeforeSendAsync(_request, new CancellationToken()));
+            Assert.AreEqual(type, ex.ProblemDetails.Type);
+            Assert.AreEqual(title, ex.ProblemDetails.Title);
+            Assert.AreEqual(status, ex.ProblemDetails.Status);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
Resolves Issue https://github.com/Laserfiche/lf-api-client-core-dotnet/issues/57

Changes
- Removed duplicate `ApiException` and `ProblemDetails` from namespaces `Laserfiche.Api.Client.APIServer` and `Laserfiche.Api.Client.OAuth` and have just one in namespace `Laserfiche.Api.Client`
- Add extra properties (`OperationId`, `ErrorSource`, `ErrorCode`, `TraceId` ) to the `ProblemDetails`
- Remove the `ApiException<T>` type and instead always throw `ApiException` to be more consistent with error handling in the repository client.