### PR TITLE
Enable self-hosted integration test on pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,15 @@ jobs:
       run:
         dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
+    - name: Run integration tests on API Server
+      env:
+        REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
+        APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
+        APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
+        APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+      run:
+        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: success() || failure()    # run this step even if previous step failed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
     - name: Run integration tests
+      id: cloud-integration-test
       env:
         ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
         SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
@@ -40,6 +41,7 @@ jobs:
         dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
     - name: Run integration tests on API Server
+      if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
       env:
         REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
         APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
         APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
         APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
       run:
         dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
 


### PR DESCRIPTION
1. Added a step for integration test on API Server in main.yml. The integration test for the self-hosted is only run when that for the cloud is run, no matter if it succeeds or fails.
2. Added repository secrets for required credentials