### PR TITLE
Add missing default JsonSerializerSettings

### DIFF
--- a/src/OAuth/AccessKey.cs
+++ b/src/OAuth/AccessKey.cs
@@ -35,6 +35,8 @@ namespace Laserfiche.Api.Client.OAuth
         [JsonProperty("jwk")]
         public JsonWebKey Jwk { set; get; }
 
+        private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { MaxDepth = 128 };
+
         /// <summary>
         /// Creates an AccessKey using the base-64 encoded access key associated with an OAuth service app,
         /// which can be exported from the Laserfiche Developer Console.
@@ -52,7 +54,7 @@ namespace Laserfiche.Api.Client.OAuth
             var accessKeyStr = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedAccessKey));
             try
             {
-                AccessKey accessKey = JsonConvert.DeserializeObject<AccessKey>(accessKeyStr);
+                AccessKey accessKey = JsonConvert.DeserializeObject<AccessKey>(accessKeyStr, jsonSerializerSettings);
                 return accessKey;
             }
             catch(JsonReaderException e)

--- a/tests/unit/ApiExceptionTests.cs
+++ b/tests/unit/ApiExceptionTests.cs
@@ -8,6 +8,8 @@ namespace Laserfiche.Api.Client.UnitTest
     [TestClass]
     public class ApiExceptionTests
     {
+        private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { MaxDepth = 128 };
+
         private void AssertNullProblemDetailsOptionalProperties(ProblemDetails problemDetails)
         {
             Assert.IsNull(problemDetails.Type);
@@ -195,10 +197,10 @@ namespace Laserfiche.Api.Client.UnitTest
                 TraceId = "TraceId",
                 Extensions = new Dictionary<string, object>() { [extensionsKey] = "value" }
             };
-            string problemDetailsResponseString = JsonConvert.SerializeObject(problemDetails);
+            string problemDetailsResponseString = JsonConvert.SerializeObject(problemDetails, jsonSerializerSettings);
             Exception innerException = new Exception("An error occurred.");
 
-            ApiException exception = ApiException.Create(statusCode, headers, problemDetailsResponseString, null, innerException);
+            ApiException exception = ApiException.Create(statusCode, headers, problemDetailsResponseString, jsonSerializerSettings, innerException);
 
             Assert.AreEqual(problemDetails.Title, exception.ProblemDetails.Title);
             Assert.AreEqual(problemDetails.Type, exception.ProblemDetails.Type);
@@ -230,7 +232,7 @@ namespace Laserfiche.Api.Client.UnitTest
             };
             Exception innerException = new Exception("An error occurred.");
 
-            ApiException exception = ApiException.Create(statusCode, headers, responseString, null, innerException);
+            ApiException exception = ApiException.Create(statusCode, headers, responseString, jsonSerializerSettings, innerException);
 
             Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
             Assert.AreEqual(statusCode, exception.ProblemDetails.Status);
@@ -252,10 +254,10 @@ namespace Laserfiche.Api.Client.UnitTest
             {
                 [ProblemDetails.OPERATION_ID_HEADER] = new List<string>() { operationId }
             };
-            var responseString = JsonConvert.SerializeObject(new Exception("An error occured."));
+            var responseString = JsonConvert.SerializeObject(new Exception("An error occured."), jsonSerializerSettings);
             Exception innerException = new Exception("An error occurred.");
 
-            ApiException exception = ApiException.Create(statusCode, headers, responseString, null, innerException);
+            ApiException exception = ApiException.Create(statusCode, headers, responseString, jsonSerializerSettings, innerException);
 
             Assert.AreEqual($"HTTP status code {statusCode}.", exception.ProblemDetails.Title);
             Assert.AreEqual(statusCode, exception.ProblemDetails.Status);

--- a/tests/unit/ProblemDetailsTests.cs
+++ b/tests/unit/ProblemDetailsTests.cs
@@ -7,6 +7,8 @@ namespace Laserfiche.Api.Client.UnitTest
     [TestClass]
     public class ProblemDetailsTests
     {
+        private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings() { MaxDepth = 128 };
+
         [TestMethod]
         public void Create_ReturnMinimalProblemDetails()
         {
@@ -59,9 +61,9 @@ namespace Laserfiche.Api.Client.UnitTest
                 Status = 400,
                 Description = "a description extension property"
             };
-            var serializedObject = JsonConvert.SerializeObject(mockProblemDetails);
+            var serializedObject = JsonConvert.SerializeObject(mockProblemDetails, jsonSerializerSettings);
 
-            var result = JsonConvert.DeserializeObject<ProblemDetails>(serializedObject);
+            var result = JsonConvert.DeserializeObject<ProblemDetails>(serializedObject, jsonSerializerSettings);
 
             Assert.AreEqual(mockProblemDetails.Title, result.Title);
             Assert.AreEqual(mockProblemDetails.Status, result.Status);
@@ -77,9 +79,9 @@ namespace Laserfiche.Api.Client.UnitTest
                 Id = 1,
                 Name = "John",
             };
-            var serializedObject = JsonConvert.SerializeObject(obj);
+            var serializedObject = JsonConvert.SerializeObject(obj, jsonSerializerSettings);
 
-            Assert.ThrowsException<JsonSerializationException>(() => JsonConvert.DeserializeObject<ProblemDetails>(serializedObject));
+            Assert.ThrowsException<JsonSerializationException>(() => JsonConvert.DeserializeObject<ProblemDetails>(serializedObject, jsonSerializerSettings));
         }
 
         private class Student


### PR DESCRIPTION
Resolves https://github.com/Laserfiche/lf-api-client-core-dotnet/security/dependabot/3 by adding default max depth when using `JsonConvert`