### PR TITLE
Change JwtUtils and function to create Authorization JWT to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.2
+
+### Features
+- Expose the `JwtUtils` class allowing clients to create an Authorization JWT used to request an Access Token.
+
 ## 1.3.1
 
 ### Features

--- a/src/Utils/JwtUtils.cs
+++ b/src/Utils/JwtUtils.cs
@@ -10,6 +10,8 @@ namespace Laserfiche.Api.Client.Utils
 {
     public static class JwtUtils
     {
+        private const string AudienceClaim = "laserfiche.com";
+
         /// <summary>
         /// Create OAuth 2.0 client_credentials Authorization JWT that can be used with Laserfiche Cloud Token endpoint to request an Access Token.
         /// The Authorization JWT will expire after 30 minutes.
@@ -36,7 +38,7 @@ namespace Laserfiche.Api.Client.Utils
                     new Claim("client_id", accessKey.ClientId),
                     new Claim("client_secret", servicePrincipalKey),
                 };
-            return CreateSignedJwt(claims, accessKey.Jwk, "laserfiche.com", validTo);
+            return CreateSignedJwt(claims, accessKey.Jwk, validTo);
         }
 
         private static SigningCredentials GetSigningCredentials(JsonWebKey key)
@@ -51,13 +53,12 @@ namespace Laserfiche.Api.Client.Utils
             return new SigningCredentials(ecdsaSecurityKey, SecurityAlgorithms.EcdsaSha256);
         }
 
-        private static string CreateSignedJwt(IEnumerable<Claim> claims, JsonWebKey key, string audience = "laserfiche.com",
-            DateTime? validTo = null)
+        private static string CreateSignedJwt(IEnumerable<Claim> claims, JsonWebKey key, DateTime? validTo = null)
         {
             var signingCredentials = GetSigningCredentials(key);
             var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Audience = audience,
+                Audience = AudienceClaim,
                 Expires = validTo,
                 Subject = new ClaimsIdentity(claims),
                 SigningCredentials = signingCredentials,

--- a/tests/unit/JwtUtilsTests.cs
+++ b/tests/unit/JwtUtilsTests.cs
@@ -47,7 +47,7 @@ namespace Laserfiche.Api.Client.UnitTest
         }
 
         [TestMethod]
-        public void CreateClientCredentialsAuthorizationJwt_WithoutExpiration()
+        public void CreateClientCredentialsAuthorizationJwt_WithNullExpiration()
         {
             string result = JwtUtils.CreateClientCredentialsAuthorizationJwt(ServicePrincipalKey, AccessKey, null);
 

--- a/tests/unit/JwtUtilsTests.cs
+++ b/tests/unit/JwtUtilsTests.cs
@@ -1,0 +1,59 @@
+﻿using Laserfiche.Api.Client.OAuth;
+using Laserfiche.Api.Client.Utils;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Laserfiche.Api.Client.UnitTest
+{
+    [TestClass]
+    public class JwtUtilsTests
+    {
+        private const string ServicePrincipalKey = "ServicePrincipalKey";
+        private readonly AccessKey AccessKey = new AccessKey()
+        {
+            ClientId = "ClientId",
+            Jwk = new Microsoft.IdentityModel.Tokens.JsonWebKey() 
+            {
+                Kty = "EC",
+                Crv = "P-256",
+                Use = "sig",
+                Kid = "TqlmmB_nwSb6Yyov9qIcJVCLdBAGhonC7C7s9kC4Avs",
+                X = "jdYj973SLwMIiuwA24TNXs1NmkvLeSzw-QBd_-_4-R8",
+                Y = "wo3hyow9__af_4dIxsiL7Zs8oa2z4BTdS9LmX71Xj3w",
+                D = "qEnaazhXsBpePbV8MYLGz8NUnt4CKW7p0utPIj_NR2k"
+            }
+        };
+
+        [TestMethod]
+        public void CreateClientCredentialsAuthorizationJwt_WithDefaultExpiration()
+        {
+            string result = JwtUtils.CreateClientCredentialsAuthorizationJwt(ServicePrincipalKey, AccessKey);
+
+            var jwt = new JsonWebToken(result);
+            Assert.AreEqual(AccessKey.Jwk.Kid, jwt.Kid);
+            Assert.IsTrue(jwt.ValidTo > DateTime.UtcNow);
+        }
+
+        [TestMethod]
+        public void CreateClientCredentialsAuthorizationJwt_WithCustomExpiration()
+        {
+            DateTime expiration = DateTime.UtcNow.AddHours(2);
+            string result = JwtUtils.CreateClientCredentialsAuthorizationJwt(ServicePrincipalKey, AccessKey, expiration);
+
+            var jwt = new JsonWebToken(result);
+            Assert.AreEqual(AccessKey.Jwk.Kid, jwt.Kid);
+            Assert.IsTrue(expiration.Subtract(jwt.ValidTo).Duration().TotalSeconds < 1);
+        }
+
+        [TestMethod]
+        public void CreateClientCredentialsAuthorizationJwt_WithoutExpiration()
+        {
+            string result = JwtUtils.CreateClientCredentialsAuthorizationJwt(ServicePrincipalKey, AccessKey, null);
+
+            var jwt = new JsonWebToken(result);
+            Assert.AreEqual(AccessKey.Jwk.Kid, jwt.Kid);
+            Assert.AreEqual(DateTime.MinValue, jwt.ValidTo);
+        }
+    }
+}


### PR DESCRIPTION
JwtUtils has been changed to public and contains two public methods
- `CreateClientCredentialsAuthorizationJwt(string servicePrincipalKey, AccessKey accessKey)` can be used to create an Authorization JWT with a safe default expire time of 30 mins.
- `CreateClientCredentialsAuthorizationJwt(string servicePrincipalKey, AccessKey accessKey, DateTime? validTo)` can be used to create an Authorization JWT with a custom expire time or no expiration