### PR TITLE
Update publish documentation step for github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,38 +106,11 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --no-restore --configuration release
-
-    - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
-
-    - name: Packaging
-      run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
-
-    - name: Publish to Nuget.org
-      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
-
-    - name: Tag commit
-      uses: rickstaa/action-create-tag@v1
-      with:
-        tag: ${{ env.PACKAGE_VERSION }}
-        commit_sha: ${{ github.sha }}
-        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    - name: echo
+      run: echo hi
 
 
   publish-production-package:
@@ -180,7 +153,7 @@ jobs:
   publish-documentation:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [ publish-production-package ]
+    needs: [ publish-preview-package ]
     steps:
     - name: Set MAJOR_VERSION environment variable
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,38 +30,38 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    # - name: Run unit tests
-    #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    - name: Run unit tests
+      run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    # - name: Run integration tests
-    #   id: cloud-integration-test
-    #   env:
-    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
+    - name: Run integration tests
+      id: cloud-integration-test
+      env:
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+      run:
+        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
-    # - name: Run integration tests on API Server
-    #   if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
-    #   env:
-    #     REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
-    #     APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
-    #     APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
-    #     APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+    - name: Run integration tests on API Server
+      if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
+      env:
+        REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
+        APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
+        APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
+        APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+      run:
+        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
 
-    # - name: Test Report
-    #   uses: dorny/test-reporter@v1
-    #   if: success() || failure()    # run this step even if previous step failed
-    #   with:
-    #     name: Test Results
-    #     path: '**/*.trx'
-    #     reporter: dotnet-trx
-    #     only-summary: 'false'
-    #     list-tests: 'failed'
-    #     fail-on-error: 'false'
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()    # run this step even if previous step failed
+      with:
+        name: Test Results
+        path: '**/*.trx'
+        reporter: dotnet-trx
+        only-summary: 'false'
+        list-tests: 'failed'
+        fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,36 +160,43 @@ jobs:
     timeout-minutes: 10
     needs: [ publish-preview-package ]
     steps:
-    - name: Set MAJOR_VERSION environment variable
+    - name: Set DOCUMENTATION_VERSION environment variable
       run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          echo "MAJOR_VERSION=${{ github.base_ref }}" >> $GITHUB_ENV
+        if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+          echo 'DOCUMENTATION_VERSION=${{ github.base_ref }}' >> $GITHUB_ENV
+        elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
+          echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
         else
-          echo "MAJOR_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo 'Unable to publish documentation for the current branch.'
+          exit 1
         fi
+
+    - name: Print DOCUMENTATION_VERSION environment variable
+      run: |
+        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
 
     - uses: actions/checkout@v3
       with:
         ref: ${{ env.GITHUB_PAGES_BRANCH }}
 
     - name: Delete documentation directory
-      run: rm -f -r ./docs/${{ env.MAJOR_VERSION }}
+      run: rm -f -r ./docs/${{ env.DOCUMENTATION_VERSION }}
 
     - name: Create documentation directory
-      run: mkdir -p ./docs/${{ env.MAJOR_VERSION }}
+      run: mkdir -p ./docs/${{ env.DOCUMENTATION_VERSION }}
 
     - name: Download documentation build artifact
       uses: actions/download-artifact@v3.0.0
       with:
         name: documentation-artifact
-        path: ./docs/${{ env.MAJOR_VERSION }}
+        path: ./docs/${{ env.DOCUMENTATION_VERSION }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4.2.3
       with:
-        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.MAJOR_VERSION }}-patch
+        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch
         delete-branch: true
-        title: "Automated documentation update for branch ${{ env.MAJOR_VERSION }}"
-        commit-message: "Update for branch ${{ env.MAJOR_VERSION }} created by action ${{ github.run_id }}"
-        body: "Automated pull request for updating the ${{ env.GITHUB_PAGES_BRANCH }} branch ${{ env.MAJOR_VERSION }} version documentation."
+        title: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        commit-message: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        body: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
         assignees: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.3.3"
+  VERSION_PREFIX: '1.3.3'
+  GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:
   build-n-test:
@@ -102,36 +103,6 @@ jobs:
       run: rm -r ./generated_documentation
 
 
-  publish-documentation:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: documentation
-    if: ${{ github.run_attempt != 1 }}
-    needs: [ build-n-test, build-documentation ] # wait for build to finish
-    steps:
-    - name: Create temporary directory
-      run: mkdir -p ./generated_documentation/html/
-
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v3.0.0
-      with:
-        name: documentation-artifact
-        path: ${{ github.workspace }}/generated_documentation/html/
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2 # Use your bucket region here
-
-    - name: Upload docs to S3 bucket
-      run: aws s3 sync ./generated_documentation/html/ s3://apiserver-publish-client-library-docs/${{ github.event.repository.name }}/docs/${{ github.ref_name }} --delete
-
-    - name: Delete temporary directory
-      run: rm -r ./generated_documentation/html/
-
-
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -204,3 +175,43 @@ jobs:
         tag: ${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+
+  publish-documentation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [ publish-production-package ]
+    steps:
+    - name: Set MAJOR_VERSION environment variable
+      run: |
+        if ${{ github.event_name == 'pull_request' }}; then
+          echo "MAJOR_VERSION=${{ github.base_ref }}" >> $GITHUB_ENV
+        else
+          echo "MAJOR_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+        fi
+
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ env.GITHUB_PAGES_BRANCH }}
+
+    - name: Delete documentation directory
+      run: rm -f -r ./docs/${{ env.MAJOR_VERSION }}
+
+    - name: Create documentation directory
+      run: mkdir -p ./docs/${{ env.MAJOR_VERSION }}
+
+    - name: Download documentation build artifact
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: documentation-artifact
+        path: ./docs/${{ env.MAJOR_VERSION }}
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4.2.3
+      with:
+        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.MAJOR_VERSION }}-patch
+        delete-branch: true
+        title: "Automated documentation update for branch ${{ env.MAJOR_VERSION }}"
+        commit-message: "Update for branch ${{ env.MAJOR_VERSION }} created by action ${{ github.run_id }}"
+        body: "Automated pull request for updating the ${{ env.GITHUB_PAGES_BRANCH }} branch ${{ env.MAJOR_VERSION }} version documentation."
+        assignees: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,7 @@ jobs:
   publish-documentation:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: github-pages
     needs: [ publish-preview-package ]
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
         elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
           echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
         else
-          echo 'Unable to publish documentation for the current branch.'
+          echo '::error::Unable to publish documentation for the current branch.'
           exit 1
         fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,11 +68,6 @@ jobs:
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
     steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-
     - uses: actions/checkout@v3
 
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,11 @@ jobs:
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
     steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
     - uses: actions/checkout@v3
 
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,11 +111,38 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     steps:
-    - name: echo
-      run: echo hi
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration release
+
+    - name: set PACKAGE_VERSION environment
+      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
+
+    - name: Packaging
+      run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
+
+    - name: Publish to Nuget.org
+      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Tag commit
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ env.PACKAGE_VERSION }}
+        commit_sha: ${{ github.sha }}
+        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
   publish-production-package:
@@ -159,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: github-pages
-    needs: [ publish-preview-package ]
+    needs: [ publish-production-package ]
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,38 +30,38 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    - name: Run unit tests
-      run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    # - name: Run unit tests
+    #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    - name: Run integration tests
-      id: cloud-integration-test
-      env:
-        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-      run:
-        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
+    # - name: Run integration tests
+    #   id: cloud-integration-test
+    #   env:
+    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
-    - name: Run integration tests on API Server
-      if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
-      env:
-        REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
-        APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
-        APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
-        APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-      run:
-        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+    # - name: Run integration tests on API Server
+    #   if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
+    #   env:
+    #     REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
+    #     APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
+    #     APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
+    #     APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
 
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()    # run this step even if previous step failed
-      with:
-        name: Test Results
-        path: '**/*.trx'
-        reporter: dotnet-trx
-        only-summary: 'false'
-        list-tests: 'failed'
-        fail-on-error: 'false'
+    # - name: Test Report
+    #   uses: dorny/test-reporter@v1
+    #   if: success() || failure()    # run this step even if previous step failed
+    #   with:
+    #     name: Test Results
+    #     path: '**/*.trx'
+    #     reporter: dotnet-trx
+    #     only-summary: 'false'
+    #     list-tests: 'failed'
+    #     fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,21 +1,20 @@
 # Laserfiche API Client Core .NET
+[![NuGet version (Laserfiche.Api.Client.Core)](https://img.shields.io/nuget/v/Laserfiche.Api.Client.Core.svg?style=flat-square)](https://www.nuget.org/packages/Laserfiche.Api.Client.Core)
+
 .NET implementation of various foundational APIs for Laserfiche, including authorization APIs such as OAuth 2.0 flows for secure and easy access to Laserfiche APIs.
 
-Documentation [Laserfiche OAuth 2.0 Authorization Server API](https://developer.laserfiche.com/libraries.html).
+## Documentation
+- [Laserfiche Developer Center](https://developer.laserfiche.com/)
+- [Laserfiche API Client Core .NET Library Documentation](https://laserfiche.github.io/lf-api-client-core-dotnet/)
 
-## Overview
-- `src` contains the implementation of the foundational authentication/authorization related code for APIs of various Laserfiche products.
-- `src\APIServer` contains all Laserfiche Self-Hosted API Server authentication/authorization related client code.
-- `src\HttpHandlers` contains a client implementation of OAuth 2.0 Client Credentials Flow.
-- `src\OAuth` contains all Laserfiche Cloud OAuth related client code.
-- `src\Utils` contains all utility functions and classes for Laserfiche APIs.
-- `tests\integration` contains all integration tests. To run them, you either use GitHub Workflows, or you could provide the `.env` files in your file system and run them there.
-- `test\unit` contains all unit tests.
+## Change Log
+
+See CHANGELOG [here](https://github.com/Laserfiche/lf-api-client-core-dotnet/blob/HEAD/CHANGELOG.md).
 
 ## How to contribute
-Technically you could use any editors you like. But it's more convenient if you are using either Visual Studio Code or Visual Studio. Here is a few useful commands for building and testing the app.
+Useful commands for building and testing the app.
 
-### Generate the oauth client
+### Generate the client
 1. Download the `nswag` command line tool. Instructions can be found [here](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
 2. From the root directory of this Git repository, run the command `pwsh generate-client.ps1`
 
@@ -23,7 +22,3 @@ Technically you could use any editors you like. But it's more convenient if you 
 ### Build, Test, and Package
 
 See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-api-client-core-dotnet/blob/HEAD/.github/workflows/main.yml).
-
-### Change Log
-
-See CHANGELOG [here](https://github.com/Laserfiche/lf-api-client-core-dotnet/blob/HEAD/CHANGELOG.md).


### PR DESCRIPTION
Changes include
- Updating the README to be consistent with other client libraries
  - See preview of it here https://github.com/Laserfiche/lf-api-client-core-dotnet/blob/add-gh-pages/README.md
- Update step for publishing documentation in pipeline
  - I already ran the step and was able to verify it created a PR with the correct documentation changes
  https://github.com/Laserfiche/lf-api-client-core-dotnet/pull/74
- GitHub pages site can be found at https://laserfiche.github.io/lf-api-client-core-dotnet/docs/1.x/index.html
