### PR TITLE
Remove version prefix from pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
         echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
 
     - id: step1
-      shell: pwsh
       run: echo "test=hello" >> "$GITHUB_OUTPUT"
     - id: step2
       run: echo "test=world" >> "$GITHUB_OUTPUT"
@@ -110,7 +109,7 @@ jobs:
       env:
         VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
       run: |
-        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = $VERSION_PREFIX|i' ./doxygen/doxygen.conf
+        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = ${{ env.VERSION_PREFIX }}|i' ./doxygen/doxygen.conf
 
     - name: Dump doxygen.conf to check rewrite
       run: head -n 200 ./doxygen/doxygen.conf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "VERSION_PREFIX=1.3.3" >> "$GITHUB_OUTPUT"
+        echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
 
     - id: step1
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "::notice::The version prefix is '$productVersion'. Verify this is correct before publishing."
+        echo "::notice::Please verify if the version prefix '$productVersion' is correct before publishing a new package from this workflow."
         echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
 
     - name: Run unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: '1.3.3'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:
@@ -30,38 +29,46 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    - name: Run unit tests
-      run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    - name: Get VERSION_PREFIX
+      shell: pwsh
+      run: |
+        $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
+        $productVersion = $dll[0].VersionInfo.ProductVersion
+        echo "Found '$($dll[0].FullName)' with version '$productVersion'"
+        echo "VERSION_PREFIX=$productVersion" >> $GITHUB_ENV
 
-    - name: Run integration tests
-      id: cloud-integration-test
-      env:
-        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-      run:
-        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
+    # - name: Run unit tests
+    #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    - name: Run integration tests on API Server
-      if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
-      env:
-        REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
-        APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
-        APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
-        APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-      run:
-        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+    # - name: Run integration tests
+    #   id: cloud-integration-test
+    #   env:
+    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()    # run this step even if previous step failed
-      with:
-        name: Test Results
-        path: '**/*.trx'
-        reporter: dotnet-trx
-        only-summary: 'false'
-        list-tests: 'failed'
-        fail-on-error: 'false'
+    # - name: Run integration tests on API Server
+    #   if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
+    #   env:
+    #     REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
+    #     APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
+    #     APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
+    #     APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+
+    # - name: Test Report
+    #   uses: dorny/test-reporter@v1
+    #   if: success() || failure()    # run this step even if previous step failed
+    #   with:
+    #     name: Test Results
+    #     path: '**/*.trx'
+    #     reporter: dotnet-trx
+    #     only-summary: 'false'
+    #     list-tests: 'failed'
+    #     fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest
@@ -69,6 +76,9 @@ jobs:
     needs: [ build-n-test ] # wait for build to finish
     steps:
     - uses: actions/checkout@v3
+
+    - name: get VERSION_PREFIX environment
+      run: echo ${{ env.VERSION_PREFIX }}
 
     - name: Install dependencies
       run: |
@@ -106,7 +116,7 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: preview
+    # environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     steps:
@@ -129,15 +139,15 @@ jobs:
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
 
-    - name: Publish to Nuget.org
-      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+    # - name: Publish to Nuget.org
+    #   run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
 
-    - name: Tag commit
-      uses: rickstaa/action-create-tag@v1
-      with:
-        tag: ${{ env.PACKAGE_VERSION }}
-        commit_sha: ${{ github.sha }}
-        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    # - name: Tag commit
+    #   uses: rickstaa/action-create-tag@v1
+    #   with:
+    #     tag: ${{ env.PACKAGE_VERSION }}
+    #     commit_sha: ${{ github.sha }}
+    #     message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
   publish-production-package:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "VERSION_PREFIX=$productVersion" >> $GITHUB_OUTPUT
+        echo "VERSION_PREFIX=$productVersion" >> "$GITHUB_OUTPUT"
 
     - id: step1
       run: echo "test=hello" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      VERSION_PREFIX: ${{ steps.get_version_prefix.outputs.VERSION_PREFIX }}
+      VERSION_PREFIX: ${{ steps.set_version_prefix.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -31,49 +31,48 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    - name: Get VERSION_PREFIX
-      id: get_version_prefix
+    - name: Set VERSION_PREFIX
+      id: set_version_prefix
       shell: pwsh
       run: |
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "::notice::VERSION_PREFIX=$productVersion"
-        echo "Summary: VERSION_PREFIX=$productVersion" >> $env:GITHUB_STEP_SUMMARY
+        echo "::notice::The version prefix is '$productVersion'. Verify this is correct before publishing."
         echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
 
-    # - name: Run unit tests
-    #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    - name: Run unit tests
+      run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    # - name: Run integration tests
-    #   id: cloud-integration-test
-    #   env:
-    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
+    - name: Run integration tests
+      id: cloud-integration-test
+      env:
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+      run:
+        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx" --filter TestCategory=Cloud
 
-    # - name: Run integration tests on API Server
-    #   if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
-    #   env:
-    #     REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
-    #     APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
-    #     APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
-    #     APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
+    - name: Run integration tests on API Server
+      if: always() && (steps.cloud-integration-test.outcome == 'success' || steps.cloud-integration-test.outcome == 'failure')
+      env:
+        REPOSITORY_ID: ${{ secrets.APISERVER_REPOSITORY_ID }}
+        APISERVER_USERNAME:  ${{ secrets.APISERVER_USERNAME }}
+        APISERVER_PASSWORD:  ${{ secrets.APISERVER_PASSWORD }}
+        APISERVER_REPOSITORY_API_BASE_URL:  ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+      run:
+        dotnet test tests/integration/Laserfiche.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx" --filter TestCategory=APIServer
 
-    # - name: Test Report
-    #   uses: dorny/test-reporter@v1
-    #   if: success() || failure()    # run this step even if previous step failed
-    #   with:
-    #     name: Test Results
-    #     path: '**/*.trx'
-    #     reporter: dotnet-trx
-    #     only-summary: 'false'
-    #     list-tests: 'failed'
-    #     fail-on-error: 'false'
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()    # run this step even if previous step failed
+      with:
+        name: Test Results
+        path: '**/*.trx'
+        reporter: dotnet-trx
+        only-summary: 'false'
+        list-tests: 'failed'
+        fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest
@@ -120,7 +119,7 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # environment: preview
+    environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     env:
@@ -145,15 +144,15 @@ jobs:
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
 
-    # - name: Publish to Nuget.org
-    #   run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+    - name: Publish to Nuget.org
+      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
 
-    # - name: Tag commit
-    #   uses: rickstaa/action-create-tag@v1
-    #   with:
-    #     tag: ${{ env.PACKAGE_VERSION }}
-    #     commit_sha: ${{ github.sha }}
-    #     message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    - name: Tag commit
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ env.PACKAGE_VERSION }}
+        commit_sha: ${{ github.sha }}
+        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
   publish-production-package:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
     timeout-minutes: 10
     outputs:
       VERSION_PREFIX: ${{ steps.get_version_prefix.outputs.VERSION_PREFIX }}
+      output1: ${{ steps.step1.outputs.test }}
+      output2: ${{ steps.step2.outputs.test }}
     steps:
     - uses: actions/checkout@v3
 
@@ -39,6 +41,11 @@ jobs:
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
         echo "VERSION_PREFIX=$productVersion" >> $GITHUB_OUTPUT
+
+    - id: step1
+      run: echo "test=hello" >> "$GITHUB_OUTPUT"
+    - id: step2
+      run: echo "test=world" >> "$GITHUB_OUTPUT"
 
     # - name: Run unit tests
     #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
@@ -78,6 +85,11 @@ jobs:
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
     steps:
+    - env:
+        OUTPUT1: ${{ needs.build-n-test.outputs.output1 }}
+        OUTPUT2: ${{ needs.build-n-test.outputs.output2 }}
+      run: echo "$OUTPUT1 $OUTPUT2"
+
     - uses: actions/checkout@v3
 
     - name: Install dependencies
@@ -94,8 +106,10 @@ jobs:
       run: mkdir -p ./generated_documentation/
 
     - name: Rewrite doxygen config
+      env:
+        VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
       run: |
-        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = ${{ needs.build-n-test.outputs.VERSION_PREFIX }}|i' ./doxygen/doxygen.conf
+        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = $VERSION_PREFIX|i' ./doxygen/doxygen.conf
 
     - name: Dump doxygen.conf to check rewrite
       run: head -n 200 ./doxygen/doxygen.conf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,6 @@ jobs:
     timeout-minutes: 10
     outputs:
       VERSION_PREFIX: ${{ steps.get_version_prefix.outputs.VERSION_PREFIX }}
-      output1: ${{ steps.step1.outputs.test }}
-      output2: ${{ steps.step2.outputs.test }}
     steps:
     - uses: actions/checkout@v3
 
@@ -41,11 +39,6 @@ jobs:
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
         echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
-
-    - id: step1
-      run: echo "test=hello" >> "$GITHUB_OUTPUT"
-    - id: step2
-      run: echo "test=world" >> "$GITHUB_OUTPUT"
 
     # - name: Run unit tests
     #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
@@ -84,12 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
-    - env:
-        OUTPUT1: ${{ needs.build-n-test.outputs.output1 }}
-        OUTPUT2: ${{ needs.build-n-test.outputs.output2 }}
-      run: echo "$OUTPUT1 $OUTPUT2"
-
     - uses: actions/checkout@v3
 
     - name: Install dependencies
@@ -106,8 +96,6 @@ jobs:
       run: mkdir -p ./generated_documentation/
 
     - name: Rewrite doxygen config
-      env:
-        VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
       run: |
         sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = ${{ env.VERSION_PREFIX }}|i' ./doxygen/doxygen.conf
 
@@ -133,6 +121,8 @@ jobs:
     # environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -148,7 +138,7 @@ jobs:
       run: dotnet build --no-restore --configuration release
 
     - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ needs.build-n-test.outputs.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
 
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
@@ -170,6 +160,8 @@ jobs:
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -185,7 +177,7 @@ jobs:
       run: dotnet build --no-restore --configuration release
 
     - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ needs.build-n-test.outputs.VERSION_PREFIX }}" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}" >> $GITHUB_ENV
 
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,8 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
-    env:
-      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -97,7 +95,7 @@ jobs:
 
     - name: Rewrite doxygen config
       run: |
-        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = ${{ env.VERSION_PREFIX }}|i' ./doxygen/doxygen.conf
+        sed -i 's|PROJECT_NUMBER         = version|PROJECT_NUMBER         = ${{ needs.build-n-test.outputs.VERSION_PREFIX }}|i' ./doxygen/doxygen.conf
 
     - name: Dump doxygen.conf to check rewrite
       run: head -n 200 ./doxygen/doxygen.conf
@@ -121,8 +119,6 @@ jobs:
     # environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
-    env:
-      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -138,7 +134,7 @@ jobs:
       run: dotnet build --no-restore --configuration release
 
     - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=${{ needs.build-n-test.outputs.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
 
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
@@ -160,8 +156,6 @@ jobs:
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
-    env:
-      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -177,7 +171,7 @@ jobs:
       run: dotnet build --no-restore --configuration release
 
     - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}" >> $GITHUB_ENV
+      run: echo "PACKAGE_VERSION=${{ needs.build-n-test.outputs.VERSION_PREFIX }}" >> $GITHUB_ENV
 
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
   build-n-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      VERSION_PREFIX: ${{ steps.get_version_prefix.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -30,12 +32,13 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Get VERSION_PREFIX
+      id: get_version_prefix
       shell: pwsh
       run: |
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "VERSION_PREFIX=$productVersion" >> $GITHUB_ENV
+        echo "VERSION_PREFIX=$productVersion" >> $GITHUB_OUTPUT
 
     # - name: Run unit tests
     #   run: dotnet test tests/unit/Laserfiche.Api.Client.UnitTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
@@ -74,11 +77,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [ build-n-test ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
-
-    - name: get VERSION_PREFIX environment
-      run: echo ${{ env.VERSION_PREFIX }}
 
     - name: Install dependencies
       run: |
@@ -119,6 +121,8 @@ jobs:
     # environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 
@@ -156,6 +160,8 @@ jobs:
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    env:
+      VERSION_PREFIX: ${{ needs.build-n-test.outputs.VERSION_PREFIX }}
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,9 +40,10 @@ jobs:
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
-        echo "VERSION_PREFIX=$productVersion" >> "$GITHUB_OUTPUT"
+        echo "VERSION_PREFIX=1.3.3" >> "$GITHUB_OUTPUT"
 
     - id: step1
+      shell: pwsh
       run: echo "test=hello" >> "$GITHUB_OUTPUT"
     - id: step2
       run: echo "test=world" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,8 @@ jobs:
         $dll = Get-Childitem -Path "./src/bin*" -Include "Laserfiche.Api.Client.Core.dll" -Recurse
         $productVersion = $dll[0].VersionInfo.ProductVersion
         echo "Found '$($dll[0].FullName)' with version '$productVersion'"
+        echo "::notice::VERSION_PREFIX=$productVersion"
+        echo "Summary: VERSION_PREFIX=$productVersion" >> $env:GITHUB_STEP_SUMMARY
         echo "VERSION_PREFIX=$productVersion" >> $env:GITHUB_OUTPUT
 
     # - name: Run unit tests


### PR DESCRIPTION
- Remove the version prefix from the pipeline. This version prefix is already in the .csproj file, so no need to duplicate it. The pipeline can read it when building the project.