### PR TITLE
changed dotnet build to publish

### DIFF
--- a/.github/workflows/veracode-scan.yml
+++ b/.github/workflows/veracode-scan.yml
@@ -1,8 +1,6 @@
 name: Veracode scan
 
 on:
-  pull_request:
-    branches: ['\d+.x']
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:

--- a/.github/workflows/veracode-scan.yml
+++ b/.github/workflows/veracode-scan.yml
@@ -1,6 +1,8 @@
 name: Veracode scan
 
 on:
+  pull_request:
+    branches: ['\d+.x']
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   schedule:
@@ -22,8 +24,8 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore --ignore-failed-sources
 
-    - name: Build solution
-      run: dotnet build --no-restore
+    - name: Publish solution
+      run: dotnet publish src/Laserfiche.Api.Client.Core.csproj --no-restore
 
     - name: Veracode Upload And Scan (Static Application Security Testing)
       uses: veracode/veracode-uploadandscan-action@0.2.6


### PR DESCRIPTION
- changed dotnet build to publish only the `Laserfiche.Api.Client.Core.csproj` file in the veracode scan pipeline step