### PR TITLE
Upgrade Newtonsoft.Json to fix veracode SCA issue.

### DIFF
--- a/src/Laserfiche.Api.Client.Core.csproj
+++ b/src/Laserfiche.Api.Client.Core.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade Newtonsoft.Json to fix veracode SCA issue.

![image](https://github.com/Laserfiche/lf-api-client-core-dotnet/assets/102711477/0de24e49-1797-4477-bd24-5910788b8f4a)
