### PR TITLE
Retrieve header value in case-insensitive mode.

### DIFF
--- a/src/ProblemDetails.cs
+++ b/src/ProblemDetails.cs
@@ -83,17 +83,18 @@ namespace Laserfiche.Api.Client
         /// <returns>ProblemDetails</returns>
         public static ProblemDetails Create(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers)
         {
+            var title = GetHeaderValue(headers, API_SERVER_ERROR_HEADER); 
             return new ProblemDetails
             {
                 Status = statusCode,
-                Title = GetHeaderValue(headers, API_SERVER_ERROR_HEADER) ?? $"HTTP status code {statusCode}.", 
+                Title = title != null ? WebUtility.UrlDecode(title) : $"HTTP status code {statusCode}.", 
                 OperationId = GetHeaderValue(headers, OPERATION_ID_HEADER)
             };
         }
 
         private static string GetHeaderValue(IReadOnlyDictionary<string, IEnumerable<string>> headers, string headerName)
         {
-            var values = headers.FirstOrDefault(entry => entry.Key.Equals(headerName, System.StringComparison.OrdinalIgnoreCase)).Value;
+            var values = headers?.FirstOrDefault(entry => entry.Key.Equals(headerName, System.StringComparison.OrdinalIgnoreCase)).Value;
             return values?.FirstOrDefault();
         }
     }

--- a/src/ProblemDetails.cs
+++ b/src/ProblemDetails.cs
@@ -93,17 +93,8 @@ namespace Laserfiche.Api.Client
 
         private static string GetHeaderValue(IReadOnlyDictionary<string, IEnumerable<string>> headers, string headerName)
         {
-            string value = null;
-            if (headers?.TryGetValue(headerName, out IEnumerable<string> values) == true)
-            {
-                value = WebUtility.UrlDecode(values.FirstOrDefault());
-            }
-            else if (headers?.TryGetValue(headerName.ToLower(), out IEnumerable<string> values2) == true)
-            {
-                value = WebUtility.UrlDecode(values2.FirstOrDefault());
-            }
-
-            return value;
+            var values = headers.FirstOrDefault(entry => entry.Key.Equals(headerName, System.StringComparison.OrdinalIgnoreCase)).Value;
+            return values?.FirstOrDefault();
         }
     }
 }

--- a/src/ProblemDetails.cs
+++ b/src/ProblemDetails.cs
@@ -86,9 +86,24 @@ namespace Laserfiche.Api.Client
             return new ProblemDetails
             {
                 Status = statusCode,
-                Title = headers?.TryGetValue(API_SERVER_ERROR_HEADER, out IEnumerable<string> apiServerErrorHeader) == true ? WebUtility.UrlDecode(apiServerErrorHeader?.FirstOrDefault()) : $"HTTP status code {statusCode}.",
-                OperationId = headers?.TryGetValue(OPERATION_ID_HEADER, out IEnumerable<string> operationIdHeader) == true ? operationIdHeader.FirstOrDefault() : null
+                Title = GetHeaderValue(headers, API_SERVER_ERROR_HEADER) ?? $"HTTP status code {statusCode}.", 
+                OperationId = GetHeaderValue(headers, OPERATION_ID_HEADER)
             };
+        }
+
+        private static string GetHeaderValue(IReadOnlyDictionary<string, IEnumerable<string>> headers, string headerName)
+        {
+            string value = null;
+            if (headers?.TryGetValue(headerName, out IEnumerable<string> values) == true)
+            {
+                value = WebUtility.UrlDecode(values.FirstOrDefault());
+            }
+            else if (headers?.TryGetValue(headerName.ToLower(), out IEnumerable<string> values2) == true)
+            {
+                value = WebUtility.UrlDecode(values2.FirstOrDefault());
+            }
+
+            return value;
         }
     }
 }


### PR DESCRIPTION
When retrieving custom header value, also try getting by lower case name.

The integration test <code>GetDocumentContentTypeAsync_ThrowException</code> fails because the X-APIServer-Error header sent by APIServer is received as x-apiserver-error.

Headers should be treated as case-insensitive.